### PR TITLE
Mark ArrayLength as an unsafe trait to prevent users from erroneously…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@ impl<N: Nat> Nat for (N, _1) {
 }
 
 /// Trait making GenericArray work
-pub trait ArrayLength<T> : Nat {
+pub unsafe trait ArrayLength<T> : Nat {
 	/// Associated type representing the array type for the number
 	type ArrayType;
 }
@@ -43,10 +43,10 @@ pub struct UnitArray<T> {
 	data: T
 }
 
-impl<T> ArrayLength<T> for _0 {
+unsafe impl<T> ArrayLength<T> for _0 {
 	type ArrayType = EmptyArray<T>;
 }
-impl<T> ArrayLength<T> for _1 {
+unsafe impl<T> ArrayLength<T> for _1 {
 	type ArrayType = UnitArray<T>;
 }
 
@@ -64,11 +64,11 @@ pub struct GenericArrayImplOdd<T, U> {
 	data: T
 }
 
-impl<T, N: ArrayLength<T>> ArrayLength<T> for (N, _0) {
+unsafe impl<T, N: ArrayLength<T>> ArrayLength<T> for (N, _0) {
 	type ArrayType = GenericArrayImplEven<T, N::ArrayType>;
 }
 
-impl<T, N: ArrayLength<T>> ArrayLength<T> for (N, _1) {
+unsafe impl<T, N: ArrayLength<T>> ArrayLength<T> for (N, _1) {
 	type ArrayType = GenericArrayImplOdd<T, N::ArrayType>;
 }
 


### PR DESCRIPTION
… implementing it.