### PR TITLE
impl IntoIterator for GenericArray

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,0 +1,97 @@
+use nodrop::NoDrop;
+use std::cmp;
+use std::ptr;
+use super::{GenericArray, ArrayLength};
+
+/// An iterator that moves out of a `GenericArray`
+pub struct GenericArrayIter<T, N: ArrayLength<T>> {
+    // Invariants: index <= index_back <= N
+    // Only values in array[index..index_back] are alive at any given time.
+    // Values from array[..index] and array[index_back..] are already moved/dropped.
+    array: NoDrop<GenericArray<T, N>>,
+    index: usize,
+    index_back: usize,
+}
+
+impl<T, N> IntoIterator for GenericArray<T, N> where N: ArrayLength<T> {
+    type Item = T;
+    type IntoIter = GenericArrayIter<T, N>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        GenericArrayIter {
+            array: NoDrop::new(self),
+            index: 0,
+            index_back: N::to_usize(),
+        }
+    }
+}
+
+impl<T, N> Drop for GenericArrayIter<T, N> where N: ArrayLength<T> {
+    fn drop(&mut self) {
+        // Drop values that are still alive.
+        for p in &mut self.array[self.index..self.index_back] {
+            unsafe { ptr::drop_in_place(p); }
+        }
+    }
+}
+
+impl<T, N> Iterator for GenericArrayIter<T, N> where N: ArrayLength<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        if self.len() > 0 {
+            unsafe {
+                let p = self.array.get_unchecked(self.index);
+                self.index += 1;
+                Some(ptr::read(p))
+            }
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.len();
+        (len, Some(len))
+    }
+
+    fn count(self) -> usize {
+        self.len()
+    }
+
+    fn nth(&mut self, n: usize) -> Option<T> {
+        // First consume values prior to the nth.
+        let ndrop = cmp::min(n, self.len());
+        for p in &mut self.array[self.index..self.index + ndrop] {
+            self.index += 1;
+            unsafe { ptr::drop_in_place(p); }
+        }
+
+        self.next()
+    }
+
+    fn last(mut self) -> Option<T> {
+        // Note, everything else will correctly drop first as `self` leaves scope.
+        self.next_back()
+    }
+}
+
+impl<T, N> DoubleEndedIterator for GenericArrayIter<T, N> where N: ArrayLength<T> {
+    fn next_back(&mut self) -> Option<T> {
+        if self.len() > 0 {
+            self.index_back -= 1;
+            unsafe {
+                let p = self.array.get_unchecked(self.index_back);
+                Some(ptr::read(p))
+            }
+        } else {
+            None
+        }
+    }
+}
+
+impl<T, N> ExactSizeIterator for GenericArrayIter<T, N> where N: ArrayLength<T> {
+    fn len(&self) -> usize {
+        self.index_back - self.index
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@ extern crate core as std;
 extern crate typenum;
 extern crate nodrop;
 pub mod arr;
+pub mod iter;
+pub use iter::GenericArrayIter;
 use nodrop::NoDrop;
 use typenum::uint::{Unsigned, UTerm, UInt};
 use typenum::bit::{B0, B1};

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -50,3 +50,8 @@ fn test_arr() {
     let test: GenericArray<u32, U3> = arr![u32; 1, 2, 3];
     assert_eq!(test[1], 2);
 }
+
+#[test]
+fn test_iter_flat_map() {
+    assert!((0..5).flat_map(|i| arr![i32; 2 * i, 2 * i + 1]).eq(0..10));
+}


### PR DESCRIPTION
This allows an array to move its values out through iteration. I find this especially handy for `flat_map`, to expand one item into several without having to allocate a `Vec`, like the new test:

```rust
fn test_iter_flat_map() {
    assert!((0..5).flat_map(|i| arr![i32; 2 * i, 2 * i + 1]).eq(0..10));
}
```

This is a spiritual successor to rust-lang/rust#32871, which was declined at least until it could use integer generics.  `GenericArray` fills that gap, though, and could use `IntoIterator` today.