### PR TITLE
Implemented Serde's `Serialize` and `Deserialize` traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,11 @@ name = "generic_array"
 [dependencies]
 typenum = "1.3.1"
 nodrop = "0.1.6"
+serde = { version = "~0.7", optional = true }
+
+[dev_dependencies]
+# this can't yet be made optional, see https://github.com/rust-lang/cargo/issues/1596
+serde_json = "~0.7"
 
 [features]
 no_std = ["typenum/no_std"]

--- a/src/impl_serde.rs
+++ b/src/impl_serde.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::ser::impls::SeqIteratorVisitor;
+use serde::de::impls::VecVisitor;
+use {ArrayLength, GenericArray};
+
+impl<T, N> Serialize for GenericArray<T, N>
+    where T: Serialize, N: ArrayLength<T> {
+    #[inline]
+    fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error>
+        where S: Serializer,
+    {
+        // serializes this array just like a slice or a vector
+        serializer.serialize_seq(SeqIteratorVisitor::new(self.iter(), Some(self.len())))
+    }
+}
+
+impl<T, N> Deserialize for GenericArray<T, N>
+    where T: Deserialize + Clone, N: ArrayLength<T>
+{
+    fn deserialize<D>(deserializer: &mut D) -> Result<GenericArray<T, N>, D::Error>
+        where D: Deserializer,
+    {
+        // this implementation has the cost of allocating a new vector each time.
+        // TODO: write a better 'allocationless' version
+        deserializer.deserialize_seq(VecVisitor::new()).map(|vec| GenericArray::from_slice(&vec))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! struct Foo<T, N> {
 //!     data: [T; N]
 //! }
-//! ``` 
+//! ```
 //!
 //! won't work.
 //!
@@ -16,14 +16,14 @@
 //! struct Foo<T, N: ArrayLength<T>> {
 //!     data: GenericArray<T,N>
 //! }
-//! ``` 
+//! ```
 //!
 //! The `ArrayLength<T>` trait is implemented by default for [unsigned integer types](../typenum/uint/index.html) from [typenum](../typenum/index.html).
 //!
 //! For ease of use, an `arr!` macro is provided - example below:
 //!
 //! ```
-//! # #[macro_use] 
+//! # #[macro_use]
 //! # extern crate generic_array;
 //! # extern crate typenum;
 //! # fn main() {
@@ -36,9 +36,15 @@
 extern crate core as std;
 extern crate typenum;
 extern crate nodrop;
+#[cfg(feature="serde")]
+extern crate serde;
 pub mod arr;
 pub mod iter;
 pub use iter::GenericArrayIter;
+
+#[cfg(feature="serde")]
+pub mod impl_serde;
+
 use nodrop::NoDrop;
 use typenum::uint::{Unsigned, UTerm, UInt};
 use typenum::bit::{B0, B1};
@@ -140,7 +146,7 @@ impl<T, N> GenericArray<T, N> where N: ArrayLength<T> {
         assert_eq!(s.len(), N::to_usize());
         map_inner(s, f)
     }
-    
+
     /// map a function over a `GenericArray`.
     pub fn map<U, F>(self, f: F) -> GenericArray<U, N>
     where F: Fn(&T) -> U, N: ArrayLength<U> {
@@ -152,7 +158,7 @@ impl<T, N> GenericArray<T, N> where N: ArrayLength<T> {
 fn map_inner<S, F, T, N>(list: &[S], f: F) -> GenericArray<T, N>
 where F: Fn(&S) -> T, N: ArrayLength<T> {
      unsafe {
-        let mut res : NoDrop<GenericArray<T, N>> = 
+        let mut res : NoDrop<GenericArray<T, N>> =
                       NoDrop::new(mem::uninitialized());
         for (s, r) in list.iter().zip(res.iter_mut()) {
             std::ptr::write(r, f(s))
@@ -166,9 +172,9 @@ impl<T: Default, N> GenericArray<T, N> where N: ArrayLength<T> {
     /// Function constructing an array filled with default values
     pub fn new() -> GenericArray<T, N> {
         unsafe {
-            let mut res : NoDrop<GenericArray<T, N>> = 
+            let mut res : NoDrop<GenericArray<T, N>> =
                           NoDrop::new(mem::uninitialized());
-            for r in res.iter_mut() { 
+            for r in res.iter_mut() {
                 ptr::write(r, T::default())
             }
             res.into_inner()
@@ -190,7 +196,7 @@ impl<T: Clone, N> GenericArray<T, N> where N: ArrayLength<T> {
 impl<T: Clone, N> Clone for GenericArray<T, N> where N: ArrayLength<T> {
     fn clone(&self) -> GenericArray<T, N> {
         unsafe {
-            let mut res : NoDrop<GenericArray<T, N>> = 
+            let mut res : NoDrop<GenericArray<T, N>> =
                           NoDrop::new(mem::uninitialized());
             for i in 0..N::to_usize() { ptr::write(&mut res[i], self[i].clone()) }
             res.into_inner()

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -55,3 +55,21 @@ fn test_arr() {
 fn test_iter_flat_map() {
     assert!((0..5).flat_map(|i| arr![i32; 2 * i, 2 * i + 1]).eq(0..10));
 }
+
+#[cfg(feature="serde")]
+mod impl_serde {
+    extern crate serde_json;
+
+    use generic_array::GenericArray;
+    use typenum::U6;
+
+    #[test]
+    fn test_serde_implementation() {
+        let array: GenericArray<f64, U6> = arr![f64; 0.0, 5.0, 3.0, 7.07192, 76.0, -9.0];
+        let string = serde_json::to_string(&array).unwrap();
+        assert_eq!(string, "[0,5,3,7.07192,76,-9]");
+
+        let test_array: GenericArray<f64, U6> = serde_json::from_str(&string).unwrap();
+        assert_eq!(test_array, array);
+    }
+}


### PR DESCRIPTION
Responds to some further comments I brought up in https://github.com/fizyk20/generic-array/issues/14

There are 3 issues with this implementation so far:
- the `Deserialize` implementation is really inefficient. I basically just copied the deserialization code for `Vec` and then called `GenericArray::from_slice()` on it. I need a better understanding of Serde to be able to deserialize without allocating/converting.
- I wrote a test using the `serde_json` crate. This had to be added as a non-optional dev-dependency, which is probably annoying for you when compiling (or I could add it as a optional normal dependency, which would then be annoying for the user of this library)
- Looking through the diff in the commit there are lines that show up as changed except they appear identical. I wonder if my editor automatically converted tabs to spaces or something?
