### PR TITLE
Re-export typenum.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ serde = { version = "~0.7", optional = true }
 serde_json = "~0.7"
 
 [features]
-no_std = ["typenum/no_std"]
+no_std = []

--- a/src/arr.rs
+++ b/src/arr.rs
@@ -1,4 +1,4 @@
-use typenum::consts::{U1};
+use typenum::U1;
 use std::ops::Add;
 use super::ArrayLength;
 
@@ -22,7 +22,7 @@ pub type Inc<T, U> = <U as AddLength<T, U1>>::Output;
 #[macro_export]
 macro_rules! arr_impl {
     ($T:ty; $N:ty, [$($x:expr),*], []) => ({
-        use typenum::consts::U0;
+        use generic_array::typenum::U0;
         use generic_array::GenericArray;
         use generic_array::arr::Inc;
         GenericArray::<$T, $N>::from_slice(&[$($x),*])

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,6 @@ pub extern crate typenum;
 extern crate nodrop;
 #[cfg(feature="serde")]
 extern crate serde;
-
 pub mod arr;
 pub mod iter;
 pub use iter::GenericArrayIter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,10 +34,11 @@
 #![cfg_attr(feature="no_std", no_std)]
 #[cfg(feature="no_std")]
 extern crate core as std;
-extern crate typenum;
+pub extern crate typenum;
 extern crate nodrop;
 #[cfg(feature="serde")]
 extern crate serde;
+
 pub mod arr;
 pub mod iter;
 pub use iter::GenericArrayIter;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,6 +1,5 @@
 #[macro_use]
 extern crate generic_array;
-// extern crate typenum;
 use generic_array::typenum::{U3, U97};
 use generic_array::GenericArray;
 use std::ops::Drop;

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate generic_array;
-extern crate typenum;
-use typenum::consts::{U3, U97};
+// extern crate typenum;
+use generic_array::typenum::{U3, U97};
 use generic_array::GenericArray;
 use std::ops::Drop;
 
@@ -61,7 +61,7 @@ mod impl_serde {
     extern crate serde_json;
 
     use generic_array::GenericArray;
-    use typenum::U6;
+    use generic_array::typenum::U6;
 
     #[test]
     fn test_serde_implementation() {


### PR DESCRIPTION
Right now, to depend on `generic-array`, one must with nearly certainty also depend on `typenum`, even if nothing is really needed directly from `typenum`.

In particular, the `arr!` macro throws an error without an `extern crate typenum`; it's a bit jarring to try to use a macro from a crate to find you must add a dependency.

In addition, `typenum` no longer needs the `no_std` flag to be built without the standard library, so that flag is no longer passed on.