### PR TITLE
Updated serde version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,11 @@ name = "generic_array"
 [dependencies]
 typenum = "1.3.1"
 nodrop = "0.1.6"
-serde = { version = "~0.7", optional = true }
+serde = { version = "~0.8", optional = true }
 
 [dev_dependencies]
 # this can't yet be made optional, see https://github.com/rust-lang/cargo/issues/1596
-serde_json = "~0.7"
+serde_json = "~0.8"
 
 [features]
 no_std = []


### PR DESCRIPTION
At the moment trying to use this crate when other crates depend on serde 0.8 creates lots of awkward errors.

The thing is, would this mean a minor or patch version bump?