### PR TITLE
Implements fmt::LowerHex and fmt::UpperHex for GenericArray<u8, N>

### DIFF
--- a/src/hex.rs
+++ b/src/hex.rs
@@ -1,0 +1,87 @@
+//! Generic array are commonly used as a return value for hash digests, so
+//! it's a good idea to allow to hexlify them easily. This module implements
+//! `std::fmt::LowerHex` and `std::fmt::UpperHex` traits.
+//!
+//! Example:
+//!
+//! ```rust
+//! # #[macro_use]
+//! # extern crate generic_array;
+//! # extern crate typenum;
+//! # fn main() {
+//! let array = arr![u8; 10, 20, 30];
+//! assert_eq!(format!("{:x}", array), "0a141e");
+//! # }
+//! ```
+//!
+use std::fmt;
+use std::str;
+use std::ops::Add;
+use typenum::*;
+use {GenericArray, ArrayLength};
+
+static LOWER_CHARS: &'static[u8] = b"0123456789abcdef";
+static UPPER_CHARS: &'static[u8] = b"0123456789ABCDEF";
+
+
+impl<T: ArrayLength<u8>> fmt::LowerHex for GenericArray<u8, T>
+    where T: Add<T>,
+          <T as Add<T>>::Output: ArrayLength<u8>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if T::to_usize() < 1024 {
+            // For small arrays use a stack allocated
+            // buffer of 2x number of bytes
+            let mut res = GenericArray::<u8, Sum<T, T>>::new();
+            for (i, c) in self.iter().enumerate() {
+                res[i*2] = LOWER_CHARS[(c >> 4) as usize];
+                res[i*2+1] = LOWER_CHARS[(c & 0xF) as usize];
+            }
+            f.write_str(unsafe { str::from_utf8_unchecked(&res) })?;
+        } else {
+            // For large array use chunks of up to 1024 bytes (2048 hex chars)
+            let mut buf = [0u8; 2048];
+            for chunk in self.chunks(1024) {
+                for (i, c) in chunk.iter().enumerate() {
+                    buf[i*2] = LOWER_CHARS[(c >> 4) as usize];
+                    buf[i*2+1] = LOWER_CHARS[(c & 0xF) as usize];
+                }
+                f.write_str(unsafe {
+                    str::from_utf8_unchecked(&buf[..chunk.len()*2])
+                })?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<T: ArrayLength<u8>> fmt::UpperHex for GenericArray<u8, T>
+    where T: Add<T>,
+          <T as Add<T>>::Output: ArrayLength<u8>,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if T::to_usize() < 1024 {
+            // For small arrays use a stack allocated
+            // buffer of 2x number of bytes
+            let mut res = GenericArray::<u8, Sum<T, T>>::new();
+            for (i, c) in self.iter().enumerate() {
+                res[i*2] = UPPER_CHARS[(c >> 4) as usize];
+                res[i*2+1] = UPPER_CHARS[(c & 0xF) as usize];
+            }
+            f.write_str(unsafe { str::from_utf8_unchecked(&res) })?;
+        } else {
+            // For large array use chunks of up to 1024 bytes (2048 hex chars)
+            let mut buf = [0u8; 2048];
+            for chunk in self.chunks(1024) {
+                for (i, c) in chunk.iter().enumerate() {
+                    buf[i*2] = UPPER_CHARS[(c >> 4) as usize];
+                    buf[i*2+1] = UPPER_CHARS[(c & 0xF) as usize];
+                }
+                f.write_str(unsafe {
+                    str::from_utf8_unchecked(&buf[..chunk.len()*2])
+                })?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -29,19 +29,22 @@ impl<T: ArrayLength<u8>> fmt::LowerHex for GenericArray<u8, T>
           <T as Add<T>>::Output: ArrayLength<u8>,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let max_digits = f.precision().unwrap_or(self.len());
         if T::to_usize() < 1024 {
             // For small arrays use a stack allocated
             // buffer of 2x number of bytes
             let mut res = GenericArray::<u8, Sum<T, T>>::new();
-            for (i, c) in self.iter().enumerate() {
+            for (i, c) in self.iter().take(max_digits).enumerate() {
                 res[i*2] = LOWER_CHARS[(c >> 4) as usize];
                 res[i*2+1] = LOWER_CHARS[(c & 0xF) as usize];
             }
-            f.write_str(unsafe { str::from_utf8_unchecked(&res) })?;
+            f.write_str(unsafe {
+                str::from_utf8_unchecked(&res[..max_digits*2])
+            })?;
         } else {
             // For large array use chunks of up to 1024 bytes (2048 hex chars)
             let mut buf = [0u8; 2048];
-            for chunk in self.chunks(1024) {
+            for chunk in self[..max_digits].chunks(1024) {
                 for (i, c) in chunk.iter().enumerate() {
                     buf[i*2] = LOWER_CHARS[(c >> 4) as usize];
                     buf[i*2+1] = LOWER_CHARS[(c & 0xF) as usize];
@@ -60,19 +63,22 @@ impl<T: ArrayLength<u8>> fmt::UpperHex for GenericArray<u8, T>
           <T as Add<T>>::Output: ArrayLength<u8>,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let max_digits = f.precision().unwrap_or(self.len());
         if T::to_usize() < 1024 {
             // For small arrays use a stack allocated
             // buffer of 2x number of bytes
             let mut res = GenericArray::<u8, Sum<T, T>>::new();
-            for (i, c) in self.iter().enumerate() {
+            for (i, c) in self.iter().take(max_digits).enumerate() {
                 res[i*2] = UPPER_CHARS[(c >> 4) as usize];
                 res[i*2+1] = UPPER_CHARS[(c & 0xF) as usize];
             }
-            f.write_str(unsafe { str::from_utf8_unchecked(&res) })?;
+            f.write_str(unsafe {
+                str::from_utf8_unchecked(&res[..max_digits*2])
+            })?;
         } else {
             // For large array use chunks of up to 1024 bytes (2048 hex chars)
             let mut buf = [0u8; 2048];
-            for chunk in self.chunks(1024) {
+            for chunk in self[..max_digits].chunks(1024) {
                 for (i, c) in chunk.iter().enumerate() {
                     buf[i*2] = UPPER_CHARS[(c >> 4) as usize];
                     buf[i*2+1] = UPPER_CHARS[(c & 0xF) as usize];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@ extern crate serde;
 pub mod arr;
 pub mod iter;
 pub use iter::GenericArrayIter;
+mod hex;
 
 #[cfg(feature="serde")]
 pub mod impl_serde;

--- a/tests/hex.rs
+++ b/tests/hex.rs
@@ -32,3 +32,15 @@ fn long_upper_hex() {
     assert_eq!(format!("{:X}", ar),
         from_utf8(&[b'0'; 4096]).unwrap());
 }
+
+#[test]
+fn truncated_lower_hex() {
+    let ar = arr![u8; 10, 20, 30, 40, 50];
+    assert_eq!(format!("{:.2x}", ar), "0a14");
+}
+
+#[test]
+fn truncated_upper_hex() {
+    let ar = arr![u8; 30, 20, 10, 17, 0];
+    assert_eq!(format!("{:.4X}", ar), "1E140A11");
+}

--- a/tests/hex.rs
+++ b/tests/hex.rs
@@ -1,0 +1,34 @@
+#[macro_use]
+extern crate generic_array;
+extern crate typenum;
+
+use std::str::from_utf8;
+use generic_array::GenericArray;
+use typenum::U2048;
+
+
+#[test]
+fn short_lower_hex() {
+    let ar = arr![u8; 10, 20, 30];
+    assert_eq!(format!("{:x}", ar), "0a141e");
+}
+
+#[test]
+fn short_upper_hex() {
+    let ar = arr![u8; 30, 20, 10];
+    assert_eq!(format!("{:X}", ar), "1E140A");
+}
+
+#[test]
+fn long_lower_hex() {
+    let ar = GenericArray::<u8, U2048>::new();
+    assert_eq!(format!("{:x}", ar),
+        from_utf8(&[b'0'; 4096]).unwrap());
+}
+
+#[test]
+fn long_upper_hex() {
+    let ar = GenericArray::<u8, U2048>::new();
+    assert_eq!(format!("{:X}", ar),
+        from_utf8(&[b'0'; 4096]).unwrap());
+}


### PR DESCRIPTION
Since this crate is very useful for hash digest libraries it's also very
useful to output value of the array in hex.

This implementation allocates a buffer for hex data on the stack and
uses `write_str`. This method is about 2x faster comparing to writing
every char to the buffer using `write_char`.

It's also 20-30 percent faster than using `rustc_serialize::hex::ToHex`.
Note, the latter also does a memory allocation which we avoid in this
implementation.

For arrays larger than 1024 bytes we don't allocate the whole hex data
on the stack but process data in 1024 bytes chunk (with 2048 bytes
buffer). The size of the chunk is chosed arbitrarily but it's smaller
than standard buffer size used for `BufReader` and `io::copy`.