### PR TITLE
Fix Issue #30 (Empty arr![] compiler error)

### DIFF
--- a/src/arr.rs
+++ b/src/arr.rs
@@ -42,10 +42,12 @@ macro_rules! arr_impl {
 }
 
 /// Macro allowing for easy generation of Generic Arrays.
+/// Example: `let test = arr![u32; 1, 2, 3];`
 #[macro_export]
 macro_rules! arr {
     ($T:ty; $($x:expr),*) => (
         arr_impl!($T; U0, [], [$($x),*])
     );
-    ($($x:expr,)*) => (arr![$($x),*])
+    ($($x:expr,)+) => (arr![$($x),*]);
+    () => ("""Macro requires a type, e.g. `let array = arr![u32; 1, 2, 3];`")
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -64,6 +64,23 @@ fn test_iter_flat_map() {
     assert!((0..5).flat_map(|i| arr![i32; 2 * i, 2 * i + 1]).eq(0..10));
 }
 
+#[test]
+fn test_unit_macro(){
+    let arr = arr![f32; 3.14];
+    assert_eq!(arr[0], 3.14);
+}
+
+#[test]
+fn test_empty_macro(){
+    let arr = arr![f32;];
+}
+
+/// This test should cause a helpful compile error if uncommented.
+// #[test]
+// fn test_empty_macro2(){
+//     let arr = arr![];
+// }
+
 #[cfg(feature="serde")]
 mod impl_serde {
     extern crate serde_json;


### PR DESCRIPTION
Added example to arr![] doc
Return a helpful error when empty macro is invoked. Syntax error hack.
Added some test cases to make sure actual zero and unit length arrays weren't broken.



Compiler Error after fix on rustc 1.13.0

```
../generic-array>cargo test
   Compiling generic-array v0.5.1 
error: macro expansion ignores token `"Macro requires a type, e.g. `let array = arr![u32; 1, 2, 3];`"` and any following
 --> <generic_array macros>:4:4
  |
4 | "" "Macro requires a type, e.g. `let array = arr![u32; 1, 2, 3];`" )
  |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
note: caused by the macro expansion here; the usage of `arr!` is likely invalid in expression context
 --> tests/mod.rs:81:15
  |
81|     let arr = arr![];
  |               ^^^^^^
```


Alternative strategy would be to return a unit type (empty tuple) array of length 0.