### PR TITLE
No default features on nodrop (no_std compatibility)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,11 @@ name = "generic_array"
 
 [dependencies]
 typenum = "1.3.1"
-nodrop = "0.1.6"
 serde = { version = "~0.8", optional = true }
+
+[dependencies.nodrop]
+version = "0.1.6"
+default-features = false
 
 [dev_dependencies]
 # this can't yet be made optional, see https://github.com/rust-lang/cargo/issues/1596


### PR DESCRIPTION
Tried to build generic-array for a no_std target and found out that nodrop's default features make it so that it pulls in std. This should fix that.