### PR TITLE
Serde 0.9 supports no_std.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "generic_array"
 
 [dependencies]
 typenum = "~1.5"
-serde = { version = "~0.9", optional = true }
+serde = { version = "~0.9", optional = true, default-features = false, features = ["collections"] }
 
 [dependencies.nodrop]
 version = "~0.1"


### PR DESCRIPTION
Currently `generic-array` depends on the `std` version of `Serde`. However, `Serde` has a no_std mode that supports deriving `Serialize` and `Deserialize`. This patch updates the version of `Serde` used by `generic-array` to work in this mode.