### PR TITLE
Do not require Clone bound for from[_mut]_slice

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,24 @@ impl<T, N> GenericArray<T, N>
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         self.deref_mut()
     }
+
+    /// Converts slice to a generic array reference with inferred length;
+    ///
+    /// Length of the slice must be equal to the length of the array
+    #[inline]
+    pub fn from_slice(slice: &[T]) -> &GenericArray<T, N> {
+        assert_eq!(slice.len(), N::to_usize());
+        unsafe { &*(slice.as_ptr() as *const GenericArray<T, N>) }
+    }
+
+    /// Converts mutable slice to a mutable generic array reference
+    ///
+    /// Length of the slice must be equal to the length of the array
+    #[inline]
+    pub fn from_mut_slice(slice: &mut [T]) -> &mut GenericArray<T, N> {
+        assert_eq!(slice.len(), N::to_usize());
+        unsafe { &mut *(slice.as_mut_ptr() as *mut GenericArray<T, N>) }
+    }
 }
 
 #[inline]
@@ -189,23 +207,5 @@ impl<T: Clone, N> GenericArray<T, N>
     pub fn clone_from_slice(list: &[T]) -> GenericArray<T, N> {
         assert_eq!(list.len(), N::to_usize());
         map_inner(list, |x: &T| x.clone())
-    }
-
-    /// Converts slice to a generic array reference with inferred length;
-    ///
-    /// Length of the slice must be equal to the length of the array
-    #[inline]
-    pub fn from_slice(slice: &[T]) -> &GenericArray<T, N> {
-        assert_eq!(slice.len(), N::to_usize());
-        unsafe { &*(slice.as_ptr() as *const GenericArray<T, N>) }
-    }
-
-    /// Converts mutable slice to a mutable generic array reference
-    ///
-    /// Length of the slice must be equal to the length of the array
-    #[inline]
-    pub fn from_mut_slice(slice: &mut [T]) -> &mut GenericArray<T, N> {
-        assert_eq!(slice.len(), N::to_usize());
-        unsafe { &mut *(slice.as_mut_ptr() as *mut GenericArray<T, N>) }
     }
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -32,6 +32,9 @@ impl Drop for TestDrop {
     }
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct NoClone<T>(T);
+
 #[test]
 fn test_drop() {
     unsafe {
@@ -73,6 +76,9 @@ fn test_from_slice() {
     let arr = [1, 2, 3, 4];
     let gen_arr = GenericArray::<_, U3>::from_slice(&arr[..3]);
     assert_eq!(&arr[..3], gen_arr.as_slice());
+    let arr = [NoClone(1u32), NoClone(2), NoClone(3), NoClone(4)];
+    let gen_arr = GenericArray::<_, U3>::from_slice(&arr[..3]);
+    assert_eq!(&arr[..3], gen_arr.as_slice());
 }
 
 #[test]
@@ -83,6 +89,12 @@ fn test_from_mut_slice() {
         gen_arr[2] = 10;
     }
     assert_eq!(arr, [1, 2, 10, 4]);
+    let mut arr = [NoClone(1u32), NoClone(2), NoClone(3), NoClone(4)];
+    {
+        let mut gen_arr = GenericArray::<_, U3>::from_mut_slice(&mut arr[..3]);
+        gen_arr[2] = NoClone(10);
+    }
+    assert_eq!(arr, [NoClone(1), NoClone(2), NoClone(10), NoClone(4)]);
 }
 
 #[test]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -29,7 +29,7 @@ fn test_drop() {
             self.0.set(self.0.get() + 1);
         }
     }
-  
+
     let drop_counter = Cell::new(0);
     {
         let _: GenericArray<TestDrop, U3> = arr![TestDrop; TestDrop(&drop_counter), TestDrop(&drop_counter), TestDrop(&drop_counter)];


### PR DESCRIPTION
from[_mut]_slice functions should not require a Clone bound.