### PR TITLE
Use $crate magic in arr macro

### DIFF
--- a/src/arr.rs
+++ b/src/arr.rs
@@ -22,22 +22,19 @@ pub type Inc<T, U> = <U as AddLength<T, U1>>::Output;
 #[macro_export]
 macro_rules! arr_impl {
     ($T:ty; $N:ty, [$($x:expr),*], []) => ({
-        use generic_array::typenum::U0;
-        use generic_array::GenericArray;
-        use generic_array::arr::Inc;
-        GenericArray::<$T, $N>::clone_from_slice(&[$($x),*])
+        $crate::GenericArray::<$T, $N>::clone_from_slice(&[$($x),*])
     });
     ($T:ty; $N:ty, [], [$x1:expr]) => (
-        arr_impl!($T; Inc<$T, $N>, [$x1], [])
+        arr_impl!($T; $crate::arr::Inc<$T, $N>, [$x1], [])
     );
     ($T:ty; $N:ty, [], [$x1:expr, $($x:expr),+]) => (
-        arr_impl!($T; Inc<$T, $N>, [$x1], [$($x),*])
+        arr_impl!($T; $crate::arr::Inc<$T, $N>, [$x1], [$($x),*])
     );
     ($T:ty; $N:ty, [$($y:expr),+], [$x1:expr]) => (
-        arr_impl!($T; Inc<$T, $N>, [$($y),*, $x1], [])
+        arr_impl!($T; $crate::arr::Inc<$T, $N>, [$($y),*, $x1], [])
     );
     ($T:ty; $N:ty, [$($y:expr),+], [$x1:expr, $($x:expr),+]) => (
-        arr_impl!($T; Inc<$T, $N>, [$($y),*, $x1], [$($x),*])
+        arr_impl!($T; $crate::arr::Inc<$T, $N>, [$($y),*, $x1], [$($x),*])
     );
 }
 
@@ -46,7 +43,7 @@ macro_rules! arr_impl {
 #[macro_export]
 macro_rules! arr {
     ($T:ty; $($x:expr),*) => (
-        arr_impl!($T; U0, [], [$($x),*])
+        arr_impl!($T; $crate::typenum::U0, [], [$($x),*])
     );
     ($($x:expr,)+) => (arr![$($x),*]);
     () => ("""Macro requires a type, e.g. `let array = arr![u32; 1, 2, 3];`")

--- a/tests/import_name.rs
+++ b/tests/import_name.rs
@@ -1,0 +1,10 @@
+#[macro_use]
+extern crate generic_array as gen_arr;
+
+use gen_arr::typenum;
+
+#[test]
+fn test_different_crate_name() {
+    let _: gen_arr::GenericArray<u32, typenum::U4> = arr![u32; 0, 1, 2, 3];
+    let _: gen_arr::GenericArray<u32, typenum::U0> = arr![u32;];
+}


### PR DESCRIPTION
This prevents errors when the crate is imported via another name:
if `generic_array` is referenced directly, but the crate is imported via
`extern crate generic_array as g_arr`, this will fail.

Additionally, avoid possible unused import warnings by not `use`ing
things in the macro expansion, instead always refer to the full path.