### PR TITLE
Add well-defined runtime and compile-time initialization algorithms for `GenericArray`

### DIFF
--- a/src/arr.rs
+++ b/src/arr.rs
@@ -1,16 +1,20 @@
+//! Implementation for `arr!` macro.
+
 use super::ArrayLength;
 use core::ops::Add;
 use typenum::U1;
 
 /// Helper trait for `arr!` macro
 pub trait AddLength<T, N: ArrayLength<T>>: ArrayLength<T> {
+    /// Resulting length
     type Output: ArrayLength<T>;
 }
 
 impl<T, N1, N2> AddLength<T, N2> for N1
-    where N1: ArrayLength<T> + Add<N2>,
-          N2: ArrayLength<T>,
-          <N1 as Add<N2>>::Output: ArrayLength<T>
+where
+    N1: ArrayLength<T> + Add<N2>,
+    N2: ArrayLength<T>,
+    <N1 as Add<N2>>::Output: ArrayLength<T>,
 {
     type Output = <N1 as Add<N2>>::Output;
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -188,7 +188,7 @@ impl<T, N: ArrayLength<T>> RecursiveArrayBuilder<T, N, U0> {
     ///
     /// If the generator function panics while initializing the array,
     /// any already initialized elements will be dropped.
-    #[inline(always)]
+    #[inline]
     pub fn generate<F>(generator: F) -> GenericArray<T, N>
     where
         F: Fn(usize) -> T,
@@ -207,6 +207,7 @@ impl<T, N: ArrayLength<T>> RecursiveArrayBuilder<T, N, U0> {
     ///
     /// If the mapping function panics, any already initialized elements in the new array
     /// will be dropped, AND any unused elements in the source array will also be dropped.
+    #[inline]
     pub fn map<U, F>(source: GenericArray<U, N>, f: F) -> GenericArray<T, N>
     where
         F: Fn(U) -> T,
@@ -225,6 +226,7 @@ impl<T, N: ArrayLength<T>> RecursiveArrayBuilder<T, N, U0> {
     /// Maps a `GenericArray` to another `GenericArray` by reference.
     ///
     /// If the mapping function panics, any already initialized elements will be dropped.
+    #[inline]
     pub fn map_ref<U, F>(source: &GenericArray<U, N>, f: F) -> GenericArray<T, N>
     where
         F: Fn(&U) -> T,
@@ -238,6 +240,7 @@ impl<T, N: ArrayLength<T>> RecursiveArrayBuilder<T, N, U0> {
     ///
     /// If the mapping function panics, any already initialized elements in the new array
     /// will be dropped, AND any unused elements in the source arrays will also be dropped.
+    #[inline]
     pub fn zip<A, B, F>(
         lhs: GenericArray<A, N>,
         rhs: GenericArray<B, N>,
@@ -262,6 +265,7 @@ impl<T, N: ArrayLength<T>> RecursiveArrayBuilder<T, N, U0> {
     /// initializing a new `GenericArray` with the result of the zipped mapping function.
     ///
     /// If the mapping function panics, any already initialized elements will be dropped.
+    #[inline]
     pub fn zip_ref<A, B, F>(
         lhs: &GenericArray<A, N>,
         rhs: &GenericArray<B, N>,
@@ -408,7 +412,7 @@ impl<T, N: ArrayLength<T>> IterableArrayLength<T, N> for UTerm {
     #[doc(hidden)]
     type Index = N;
 
-    #[inline(always)]
+    #[inline]
     fn generate<F>(builder: RecursiveArrayBuilder<T, N, Self::Index>, _: F) -> GenericArray<T, N>
     where
         F: Fn(usize) -> T,
@@ -420,7 +424,7 @@ impl<T, N: ArrayLength<T>> IterableArrayLength<T, N> for UTerm {
         array.into_inner()
     }
 
-    #[inline(always)]
+    #[inline]
     fn map<U, F>(
         builder: RecursiveArrayBuilder<T, N, Self::Index>,
         source: GenericArrayConsumer<U, N, Self::Index>,
@@ -438,7 +442,7 @@ impl<T, N: ArrayLength<T>> IterableArrayLength<T, N> for UTerm {
         array.into_inner()
     }
 
-    #[inline(always)]
+    #[inline]
     fn zip<A, B, F>(
         builder: RecursiveArrayBuilder<T, N, Self::Index>,
         lhs: GenericArrayConsumer<A, N, Self::Index>,
@@ -469,7 +473,7 @@ where
     #[doc(hidden)]
     type Index = <N as Sub<UInt<U, B>>>::Output;
 
-    #[inline(always)]
+    #[inline]
     fn generate<F>(builder: RecursiveArrayBuilder<T, N, Self::Index>, generator: F) -> GenericArray<T, N>
     where
         F: Fn(usize) -> T

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,545 @@
+//! Provides compile-time and runtime algorithms for safely generating `GenericArray` instances.
+//!
+//! These all use wrapper structures internally for generating and consuming arrays in a way that
+//! properly drops all created or remaining valid elements when the parent structure is dropped,
+//! such as when the mapping functions panic.
+
+use super::{ArrayLength, GenericArray};
+use core::{mem, ptr};
+use core::marker::PhantomData;
+use core::ops::{Add, Sub};
+
+use nodrop::NoDrop;
+use typenum::{Add1, IsLess, Same, Sub1, Unsigned};
+use typenum::bit::{B1, Bit};
+use typenum::consts::{True, U0};
+use typenum::uint::{UInt, UTerm};
+
+struct ArrayConsumer<T, N: ArrayLength<T>> {
+    array: NoDrop<GenericArray<T, N>>,
+    position: usize,
+}
+
+impl<T, N: ArrayLength<T>> ArrayConsumer<T, N> {
+    fn new(array: GenericArray<T, N>) -> ArrayConsumer<T, N> {
+        ArrayConsumer {
+            array: NoDrop::new(array),
+            position: 0,
+        }
+    }
+}
+
+impl<T, N: ArrayLength<T>> Drop for ArrayConsumer<T, N> {
+    fn drop(&mut self) {
+        for i in self.position..N::to_usize() {
+            unsafe {
+                ptr::drop_in_place(self.array.get_unchecked_mut(i));
+            }
+        }
+    }
+}
+
+struct ArrayBuilder<T, N: ArrayLength<T>> {
+    array: NoDrop<GenericArray<T, N>>,
+    position: usize,
+}
+
+impl<T, N: ArrayLength<T>> ArrayBuilder<T, N> {
+    fn new() -> ArrayBuilder<T, N> {
+        ArrayBuilder {
+            array: NoDrop::new(unsafe { mem::uninitialized() }),
+            position: 0,
+        }
+    }
+}
+
+impl<T, N: ArrayLength<T>> Drop for ArrayBuilder<T, N> {
+    fn drop(&mut self) {
+        for value in self.array.iter_mut().take(self.position) {
+            unsafe {
+                ptr::drop_in_place(value);
+            }
+        }
+    }
+}
+
+/// Initializes a new `GenericArray` instance using the given function.
+///
+/// If the generator function panics while initializing the array,
+/// any already initialized elements will be dropped.
+#[inline]
+pub fn generate<T, N, F>(f: F) -> GenericArray<T, N>
+where
+    F: Fn(usize) -> T,
+    N: ArrayLength<T>,
+{
+    let mut destination = ArrayBuilder::new();
+
+    for (i, dst) in destination.array.iter_mut().enumerate() {
+        unsafe {
+            ptr::write(dst, f(i));
+        }
+
+        destination.position += 1;
+    }
+
+    let array = unsafe { ptr::read(&destination.array) };
+
+    mem::forget(destination);
+
+    array.into_inner()
+}
+
+/// Maps a `GenericArray` to another `GenericArray`.
+///
+/// If the mapping function panics, any already initialized elements in the new array
+/// will be dropped, AND any unused elements in the source array will also be dropped.
+#[inline]
+pub fn map<T, U, N, F>(array: GenericArray<T, N>, f: F) -> GenericArray<U, N>
+where
+    F: Fn(T) -> U,
+    N: ArrayLength<T> + ArrayLength<U>,
+{
+    let mut source = ArrayConsumer::new(array);
+    let mut destination = ArrayBuilder::new();
+
+    for (dst, src) in destination.array.iter_mut().zip(source.array.iter()) {
+        unsafe {
+            ptr::write(dst, f(ptr::read(src)));
+        }
+
+        source.position += 1;
+        destination.position += 1;
+    }
+
+    let array = unsafe { ptr::read(&destination.array) };
+
+    mem::forget((source, destination));
+
+    array.into_inner()
+}
+
+/// Combines two `GenericArray` instances and iterates through both of them,
+/// initializing a new `GenericArray` with the result of the zipped mapping function.
+///
+/// If the mapping function panics, any already initialized elements in the new array
+/// will be dropped, AND any unused elements in the source arrays will also be dropped.
+#[inline]
+pub fn zip<A, B, T, N, F>(
+    lhs: GenericArray<A, N>,
+    rhs: GenericArray<B, N>,
+    f: F,
+) -> GenericArray<T, N>
+where
+    F: Fn(A, B) -> T,
+    N: ArrayLength<A> + ArrayLength<B> + ArrayLength<T>,
+{
+    let mut left = ArrayConsumer::new(lhs);
+    let mut right = ArrayConsumer::new(rhs);
+
+    let mut destination = ArrayBuilder::new();
+
+    for (dst, (lhs, rhs)) in
+        destination.array.iter_mut().zip(left.array.iter().zip(
+            right.array.iter(),
+        ))
+    {
+        unsafe {
+            ptr::write(dst, f(ptr::read(lhs), ptr::read(rhs)));
+        }
+
+        destination.position += 1;
+        left.position += 1;
+        right.position += 1;
+    }
+
+    let array = unsafe { ptr::read(&destination.array) };
+
+    mem::forget((left, right, destination));
+
+    array.into_inner()
+}
+
+/// Provides compile-time and pseudo-runtime algorithms for generating `GenericArray` instances.
+///
+/// Initialization methods for `RecursiveArrayBuilder` are designed so that if
+/// an error occurs while generating the array, any already initialized elements will be dropped.
+///
+/// Most of these use type-level recursion to iterate `GenericArray`s,
+/// so most expressions can be inlined and simplified at compile-time.
+///
+/// The `IterableArrayLength` trait is implemented for basically any
+pub struct RecursiveArrayBuilder<T, N: ArrayLength<T>, P: Unsigned> {
+    array: NoDrop<GenericArray<T, N>>,
+    _position: PhantomData<P>,
+}
+
+impl<T, N: ArrayLength<T>> RecursiveArrayBuilder<T, N, U0> {
+    /// Creates a new `RecursiveArrayBuilder` that starts at the first element.
+    #[must_use]
+    pub fn new() -> RecursiveArrayBuilder<T, N, U0> {
+        RecursiveArrayBuilder {
+            array: NoDrop::new(unsafe { mem::uninitialized() }),
+            _position: PhantomData,
+        }
+    }
+
+    /// Initializes a new `GenericArray` instance using the given function.
+    ///
+    /// If the generator function panics while initializing the array,
+    /// any already initialized elements will be dropped.
+    #[inline(always)]
+    pub fn generate<F>(generator: F) -> GenericArray<T, N>
+    where
+        F: Fn(usize) -> T,
+        N: IterableArrayLength<T, N>,
+    {
+        <N as IterableArrayLength<T, N>>::generate(
+            RecursiveArrayBuilder {
+                array: NoDrop::new(unsafe { mem::uninitialized() }),
+                _position: PhantomData,
+            },
+            generator,
+        )
+    }
+
+    /// Maps a `GenericArray` to another `GenericArray`.
+    ///
+    /// If the mapping function panics, any already initialized elements in the new array
+    /// will be dropped, AND any unused elements in the source array will also be dropped.
+    pub fn map<U, F>(source: GenericArray<U, N>, f: F) -> GenericArray<T, N>
+    where
+        F: Fn(U) -> T,
+        N: ArrayLength<U> + IterableArrayLength<T, N>,
+    {
+        <N as IterableArrayLength<T, N>>::map(
+            RecursiveArrayBuilder {
+                array: NoDrop::new(unsafe { mem::uninitialized() }),
+                _position: PhantomData,
+            },
+            GenericArrayConsumer::new(source),
+            f,
+        )
+    }
+
+    /// Maps a `GenericArray` to another `GenericArray` by reference.
+    ///
+    /// If the mapping function panics, any already initialized elements will be dropped.
+    pub fn map_ref<U, F>(source: &GenericArray<U, N>, f: F) -> GenericArray<T, N>
+    where
+        F: Fn(&U) -> T,
+        N: ArrayLength<U> + IterableArrayLength<T, N>,
+    {
+        RecursiveArrayBuilder::generate(move |i| f(unsafe { source.get_unchecked(i) }))
+    }
+
+    /// Combines two `GenericArray` instances and iterates through both of them,
+    /// initializing a new `GenericArray` with the result of the zipped mapping function.
+    ///
+    /// If the mapping function panics, any already initialized elements in the new array
+    /// will be dropped, AND any unused elements in the source arrays will also be dropped.
+    pub fn zip<A, B, F>(
+        lhs: GenericArray<A, N>,
+        rhs: GenericArray<B, N>,
+        f: F,
+    ) -> GenericArray<T, N>
+    where
+        F: Fn(A, B) -> T,
+        N: ArrayLength<A> + ArrayLength<B> + IterableArrayLength<T, N>,
+    {
+        <N as IterableArrayLength<T, N>>::zip(
+            RecursiveArrayBuilder {
+                array: NoDrop::new(unsafe { mem::uninitialized() }),
+                _position: PhantomData,
+            },
+            GenericArrayConsumer::new(lhs),
+            GenericArrayConsumer::new(rhs),
+            f,
+        )
+    }
+
+    /// Combines two `GenericArray` instances and iterates through both of them by reference,
+    /// initializing a new `GenericArray` with the result of the zipped mapping function.
+    ///
+    /// If the mapping function panics, any already initialized elements will be dropped.
+    pub fn zip_ref<A, B, F>(
+        lhs: &GenericArray<A, N>,
+        rhs: &GenericArray<B, N>,
+        f: F,
+    ) -> GenericArray<T, N>
+    where
+        F: Fn(&A, &B) -> T,
+        N: ArrayLength<A> + ArrayLength<B> + IterableArrayLength<T, N>,
+    {
+        RecursiveArrayBuilder::generate(move |i| unsafe {
+            f(lhs.get_unchecked(i), rhs.get_unchecked(i))
+        })
+    }
+}
+
+impl<T, N: ArrayLength<T>, P: Unsigned> RecursiveArrayBuilder<T, N, P>
+where
+    P: IsLess<N, Output = True>,
+    P: Add<B1>,
+    Add1<P>: Unsigned,
+{
+    /// Apply the generator function to the current element and
+    /// return a builder for the next element.
+    #[must_use]
+    pub fn next<F>(self, f: F) -> RecursiveArrayBuilder<T, N, Add1<P>>
+    where
+        F: Fn() -> T,
+    {
+        RecursiveArrayBuilder {
+            array: unsafe {
+                // move array out of self
+                let mut arr = ptr::read(&self.array);
+
+                // forget self
+                mem::forget(self);
+
+                // write new value to position
+                ptr::write(arr.get_unchecked_mut(P::to_usize()), f());
+
+                arr
+            },
+            _position: PhantomData,
+        }
+    }
+}
+
+impl<T, N: ArrayLength<T>, P: Unsigned> RecursiveArrayBuilder<T, N, P>
+where
+    P: Same<N>,
+{
+    /// Returns the finished `GenericArray` instance.
+    pub fn finish(self) -> GenericArray<T, N> {
+        let arr = unsafe { ptr::read(&self.array) };
+
+        mem::forget(self);
+
+        arr.into_inner()
+    }
+}
+
+impl<T, N: ArrayLength<T>, P: Unsigned> Drop for RecursiveArrayBuilder<T, N, P> {
+    fn drop(&mut self) {
+        for value in self.array.iter_mut().take(P::to_usize()) {
+            unsafe {
+                ptr::drop_in_place(value);
+            }
+        }
+    }
+}
+
+#[doc(hidden)]
+pub struct GenericArrayConsumer<T, N: ArrayLength<T>, P: Unsigned> {
+    array: NoDrop<GenericArray<T, N>>,
+    _position: PhantomData<P>,
+}
+
+impl<T, N: ArrayLength<T>, P: Unsigned> GenericArrayConsumer<T, N, P> {
+    fn new(array: GenericArray<T, N>) -> GenericArrayConsumer<T, N, P> {
+        GenericArrayConsumer {
+            array: NoDrop::new(array),
+            _position: PhantomData,
+        }
+    }
+
+    #[inline(always)]
+    fn cast<O: Unsigned>(self) -> GenericArrayConsumer<T, N, O> {
+        GenericArrayConsumer {
+            array: unsafe {
+                let array = ptr::read(&self.array);
+
+                mem::forget(self);
+
+                array
+            },
+            _position: PhantomData,
+        }
+    }
+}
+
+impl<T, N: ArrayLength<T>, P: Unsigned> Drop for GenericArrayConsumer<T, N, P> {
+    fn drop(&mut self) {
+        for i in P::to_usize()..N::to_usize() {
+            unsafe {
+                ptr::drop_in_place(self.array.get_unchecked_mut(i));
+            }
+        }
+    }
+}
+
+/// Internal trait for type-level recursion of array lengths from N to zero,
+/// allowing for compile-time evaluation of array iteration.
+pub trait IterableArrayLength<T, N: ArrayLength<T>>: ArrayLength<T> {
+    #[doc(hidden)]
+    type Index: ArrayLength<T>;
+
+    #[doc(hidden)]
+    fn generate<F>(builder: RecursiveArrayBuilder<T, N, Self::Index>, f: F) -> GenericArray<T, N>
+    where
+        F: Fn(usize) -> T;
+
+    #[doc(hidden)]
+    fn map<U, F>(
+        builder: RecursiveArrayBuilder<T, N, Self::Index>,
+        source: GenericArrayConsumer<U, N, Self::Index>,
+        f: F,
+    ) -> GenericArray<T, N>
+    where
+        F: Fn(U) -> T,
+        N: ArrayLength<U>;
+
+    #[doc(hidden)]
+    fn zip<A, B, F>(
+        builder: RecursiveArrayBuilder<T, N, Self::Index>,
+        lhs: GenericArrayConsumer<A, N, Self::Index>,
+        rhs: GenericArrayConsumer<B, N, Self::Index>,
+        f: F,
+    ) -> GenericArray<T, N>
+    where
+        F: Fn(A, B) -> T,
+        N: ArrayLength<A> + ArrayLength<B>;
+}
+
+impl<T, N: ArrayLength<T>> IterableArrayLength<T, N> for UTerm {
+    #[doc(hidden)]
+    type Index = N;
+
+    #[inline(always)]
+    fn generate<F>(builder: RecursiveArrayBuilder<T, N, Self::Index>, _: F) -> GenericArray<T, N>
+    where
+        F: Fn(usize) -> T,
+    {
+        let array = unsafe { ptr::read(&builder.array) };
+
+        mem::forget(builder);
+
+        array.into_inner()
+    }
+
+    #[inline(always)]
+    fn map<U, F>(
+        builder: RecursiveArrayBuilder<T, N, Self::Index>,
+        source: GenericArrayConsumer<U, N, Self::Index>,
+        _: F,
+    ) -> GenericArray<T, N>
+    where
+        F: Fn(U) -> T,
+        N: ArrayLength<U>,
+    {
+        let array = unsafe { ptr::read(&builder.array) };
+
+        mem::forget(source);
+        mem::forget(builder);
+
+        array.into_inner()
+    }
+
+    #[inline(always)]
+    fn zip<A, B, F>(
+        builder: RecursiveArrayBuilder<T, N, Self::Index>,
+        lhs: GenericArrayConsumer<A, N, Self::Index>,
+        rhs: GenericArrayConsumer<B, N, Self::Index>,
+        _: F,
+    ) -> GenericArray<T, N>
+    where
+        F: Fn(A, B) -> T,
+        N: ArrayLength<A> + ArrayLength<B>,
+    {
+        let array = unsafe { ptr::read(&builder.array) };
+
+        mem::forget(lhs);
+        mem::forget(rhs);
+        mem::forget(builder);
+
+        array.into_inner()
+    }
+}
+
+impl<T, N: ArrayLength<T>, U: Unsigned, B: Bit> IterableArrayLength<T, N> for UInt<U, B>
+where
+    Self: ArrayLength<T> + Sub<B1>,
+    Sub1<Self>: IterableArrayLength<T, N>,
+    N: Sub<UInt<U, B>>,
+    <N as Sub<UInt<U, B>>>::Output: ArrayLength<T>,
+{
+    #[doc(hidden)]
+    type Index = <N as Sub<UInt<U, B>>>::Output;
+
+    #[inline(always)]
+    fn generate<F>(builder: RecursiveArrayBuilder<T, N, Self::Index>, generator: F) -> GenericArray<T, N>
+    where
+        F: Fn(usize) -> T
+    {
+        <Sub1<Self> as IterableArrayLength<T, N>>::generate(RecursiveArrayBuilder {
+            array: unsafe {
+                let mut arr = ptr::read(&builder.array);
+
+                ptr::write(arr.get_unchecked_mut(Self::Index::to_usize()),
+                           generator(Self::Index::to_usize()));
+
+                mem::forget(builder);
+
+                arr
+            },
+            _position: PhantomData,
+        }, generator)
+    }
+
+    #[inline]
+    fn map<K, F>(
+        builder: RecursiveArrayBuilder<T, N, Self::Index>,
+        mut source: GenericArrayConsumer<K, N, Self::Index>,
+        f: F
+    ) -> GenericArray<T, N>
+    where
+        F: Fn(K) -> T,
+        N: ArrayLength<K>
+    {
+        <Sub1<Self> as IterableArrayLength<T, N>>::map(RecursiveArrayBuilder {
+            array: unsafe {
+                let mut arr = ptr::read(&builder.array);
+
+                ptr::write(arr.get_unchecked_mut(Self::Index::to_usize()), f(
+                    ptr::read(source.array.get_unchecked_mut(Self::Index::to_usize()))
+                ));
+
+                mem::forget(builder);
+
+                arr
+            },
+            _position: PhantomData,
+        }, source.cast(), f)
+    }
+
+    #[inline]
+    fn zip<A, K, F>(
+        builder: RecursiveArrayBuilder<T, N, Self::Index>,
+        mut lhs: GenericArrayConsumer<A, N, Self::Index>,
+        mut rhs: GenericArrayConsumer<K, N, Self::Index>,
+        f: F
+    ) -> GenericArray<T, N>
+    where
+        F: Fn(A, K) -> T,
+        N: ArrayLength<A> + ArrayLength<K>
+    {
+        <Sub1<Self> as IterableArrayLength<T, N>>::zip(RecursiveArrayBuilder {
+            array: unsafe {
+                let mut arr = ptr::read(&builder.array);
+
+                ptr::write(arr.get_unchecked_mut(Self::Index::to_usize()), f(
+                    ptr::read(lhs.array.get_unchecked_mut(Self::Index::to_usize())),
+                    ptr::read(rhs.array.get_unchecked_mut(Self::Index::to_usize()))
+                ));
+
+                mem::forget(builder);
+
+                arr
+            },
+            _position: PhantomData
+        }, lhs.cast(), rhs.cast(), f)
+    }
+}

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -26,8 +26,9 @@ static UPPER_CHARS: &'static [u8] = b"0123456789ABCDEF";
 
 
 impl<T: ArrayLength<u8>> fmt::LowerHex for GenericArray<u8, T>
-    where T: Add<T>,
-          <T as Add<T>>::Output: ArrayLength<u8>
+where
+    T: Add<T>,
+    <T as Add<T>>::Output: ArrayLength<u8>,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let max_digits = f.precision().unwrap_or(self.len());
@@ -39,7 +40,9 @@ impl<T: ArrayLength<u8>> fmt::LowerHex for GenericArray<u8, T>
                 res[i * 2] = LOWER_CHARS[(c >> 4) as usize];
                 res[i * 2 + 1] = LOWER_CHARS[(c & 0xF) as usize];
             }
-            f.write_str(unsafe { str::from_utf8_unchecked(&res[..max_digits * 2]) })?;
+            f.write_str(
+                unsafe { str::from_utf8_unchecked(&res[..max_digits * 2]) },
+            )?;
         } else {
             // For large array use chunks of up to 1024 bytes (2048 hex chars)
             let mut buf = [0u8; 2048];
@@ -48,7 +51,9 @@ impl<T: ArrayLength<u8>> fmt::LowerHex for GenericArray<u8, T>
                     buf[i * 2] = LOWER_CHARS[(c >> 4) as usize];
                     buf[i * 2 + 1] = LOWER_CHARS[(c & 0xF) as usize];
                 }
-                f.write_str(unsafe { str::from_utf8_unchecked(&buf[..chunk.len() * 2]) })?;
+                f.write_str(unsafe {
+                    str::from_utf8_unchecked(&buf[..chunk.len() * 2])
+                })?;
             }
         }
         Ok(())
@@ -56,8 +61,9 @@ impl<T: ArrayLength<u8>> fmt::LowerHex for GenericArray<u8, T>
 }
 
 impl<T: ArrayLength<u8>> fmt::UpperHex for GenericArray<u8, T>
-    where T: Add<T>,
-          <T as Add<T>>::Output: ArrayLength<u8>
+where
+    T: Add<T>,
+    <T as Add<T>>::Output: ArrayLength<u8>,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let max_digits = f.precision().unwrap_or(self.len());
@@ -69,7 +75,9 @@ impl<T: ArrayLength<u8>> fmt::UpperHex for GenericArray<u8, T>
                 res[i * 2] = UPPER_CHARS[(c >> 4) as usize];
                 res[i * 2 + 1] = UPPER_CHARS[(c & 0xF) as usize];
             }
-            f.write_str(unsafe { str::from_utf8_unchecked(&res[..max_digits * 2]) })?;
+            f.write_str(
+                unsafe { str::from_utf8_unchecked(&res[..max_digits * 2]) },
+            )?;
         } else {
             // For large array use chunks of up to 1024 bytes (2048 hex chars)
             let mut buf = [0u8; 2048];
@@ -78,7 +86,9 @@ impl<T: ArrayLength<u8>> fmt::UpperHex for GenericArray<u8, T>
                     buf[i * 2] = UPPER_CHARS[(c >> 4) as usize];
                     buf[i * 2 + 1] = UPPER_CHARS[(c & 0xF) as usize];
                 }
-                f.write_str(unsafe { str::from_utf8_unchecked(&buf[..chunk.len() * 2]) })?;
+                f.write_str(unsafe {
+                    str::from_utf8_unchecked(&buf[..chunk.len() * 2])
+                })?;
             }
         }
         Ok(())

--- a/src/impl_serde.rs
+++ b/src/impl_serde.rs
@@ -5,12 +5,14 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde::de::{self, SeqAccess, Visitor};
 
 impl<T, N> Serialize for GenericArray<T, N>
-    where T: Serialize,
-          N: ArrayLength<T>
+where
+    T: Serialize,
+    N: ArrayLength<T>,
 {
     #[inline]
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-        where S: Serializer
+    where
+        S: Serializer,
     {
         serializer.collect_seq(self.iter())
     }
@@ -22,8 +24,9 @@ struct GAVisitor<T, N> {
 }
 
 impl<'de, T, N> Visitor<'de> for GAVisitor<T, N>
-    where T: Deserialize<'de> + Default,
-          N: ArrayLength<T>
+where
+    T: Deserialize<'de> + Default,
+    N: ArrayLength<T>,
 {
     type Value = GenericArray<T, N>;
 
@@ -32,23 +35,27 @@ impl<'de, T, N> Visitor<'de> for GAVisitor<T, N>
     }
 
     fn visit_seq<A>(self, mut seq: A) -> Result<GenericArray<T, N>, A::Error>
-        where A: SeqAccess<'de>
+    where
+        A: SeqAccess<'de>,
     {
         let mut result = GenericArray::default();
         for i in 0..N::to_usize() {
-            result[i] = seq.next_element()?
-                .ok_or_else(|| de::Error::invalid_length(i, &self))?;
+            result[i] = seq.next_element()?.ok_or_else(
+                || de::Error::invalid_length(i, &self),
+            )?;
         }
         Ok(result)
     }
 }
 
 impl<'de, T, N> Deserialize<'de> for GenericArray<T, N>
-    where T: Deserialize<'de> + Default,
-          N: ArrayLength<T>
+where
+    T: Deserialize<'de> + Default,
+    N: ArrayLength<T>,
 {
     fn deserialize<D>(deserializer: D) -> Result<GenericArray<T, N>, D::Error>
-        where D: Deserializer<'de>
+    where
+        D: Deserializer<'de>,
     {
         let visitor = GAVisitor {
             _t: PhantomData,

--- a/src/impl_serde.rs
+++ b/src/impl_serde.rs
@@ -1,3 +1,5 @@
+//! Serde serialization/deserialization implementation
+
 use {ArrayLength, GenericArray};
 use core::fmt;
 use core::marker::PhantomData;

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,23 +1,16 @@
 use super::{ArrayLength, GenericArray};
-use core::{mem, ptr};
 use core::borrow::{Borrow, BorrowMut};
 use core::cmp::Ordering;
 use core::fmt::{self, Debug};
 use core::hash::{Hash, Hasher};
-use nodrop::NoDrop;
 
 impl<T: Default, N> Default for GenericArray<T, N>
 where
     N: ArrayLength<T>,
 {
+    #[inline]
     fn default() -> Self {
-        unsafe {
-            let mut res: NoDrop<GenericArray<T, N>> = NoDrop::new(mem::uninitialized());
-            for r in res.iter_mut() {
-                ptr::write(r, T::default())
-            }
-            res.into_inner()
-        }
+        Self::generate(|_| T::default())
     }
 }
 
@@ -26,13 +19,7 @@ where
     N: ArrayLength<T>,
 {
     fn clone(&self) -> GenericArray<T, N> {
-        unsafe {
-            let mut res: NoDrop<GenericArray<T, N>> = NoDrop::new(mem::uninitialized());
-            for i in 0..N::to_usize() {
-                ptr::write(&mut res[i], self[i].clone())
-            }
-            res.into_inner()
-        }
+        self.map_ref(|x| x.clone())
     }
 }
 impl<T: Copy, N> Copy for GenericArray<T, N>

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -7,7 +7,8 @@ use core::hash::{Hash, Hasher};
 use nodrop::NoDrop;
 
 impl<T: Default, N> Default for GenericArray<T, N>
-    where N: ArrayLength<T>
+where
+    N: ArrayLength<T>,
 {
     fn default() -> Self {
         unsafe {
@@ -21,7 +22,8 @@ impl<T: Default, N> Default for GenericArray<T, N>
 }
 
 impl<T: Clone, N> Clone for GenericArray<T, N>
-    where N: ArrayLength<T>
+where
+    N: ArrayLength<T>,
 {
     fn clone(&self) -> GenericArray<T, N> {
         unsafe {
@@ -34,22 +36,29 @@ impl<T: Clone, N> Clone for GenericArray<T, N>
     }
 }
 impl<T: Copy, N> Copy for GenericArray<T, N>
-    where N: ArrayLength<T>,
-          N::ArrayType: Copy
+where
+    N: ArrayLength<T>,
+    N::ArrayType: Copy,
 {
 }
 
 impl<T: PartialEq, N> PartialEq for GenericArray<T, N>
-    where N: ArrayLength<T>
+where
+    N: ArrayLength<T>,
 {
     fn eq(&self, other: &Self) -> bool {
         **self == **other
     }
 }
-impl<T: Eq, N> Eq for GenericArray<T, N> where N: ArrayLength<T> {}
+impl<T: Eq, N> Eq for GenericArray<T, N>
+where
+    N: ArrayLength<T>,
+{
+}
 
 impl<T: PartialOrd, N> PartialOrd for GenericArray<T, N>
-    where N: ArrayLength<T>
+where
+    N: ArrayLength<T>,
 {
     fn partial_cmp(&self, other: &GenericArray<T, N>) -> Option<Ordering> {
         PartialOrd::partial_cmp(&self, &other)
@@ -57,7 +66,8 @@ impl<T: PartialOrd, N> PartialOrd for GenericArray<T, N>
 }
 
 impl<T: Ord, N> Ord for GenericArray<T, N>
-    where N: ArrayLength<T>
+where
+    N: ArrayLength<T>,
 {
     fn cmp(&self, other: &GenericArray<T, N>) -> Ordering {
         Ord::cmp(&self, &other)
@@ -65,7 +75,8 @@ impl<T: Ord, N> Ord for GenericArray<T, N>
 }
 
 impl<T: Debug, N> Debug for GenericArray<T, N>
-    where N: ArrayLength<T>
+where
+    N: ArrayLength<T>,
 {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         self[..].fmt(fmt)
@@ -73,7 +84,8 @@ impl<T: Debug, N> Debug for GenericArray<T, N>
 }
 
 impl<T, N> Borrow<[T]> for GenericArray<T, N>
-    where N: ArrayLength<T>
+where
+    N: ArrayLength<T>,
 {
     fn borrow(&self) -> &[T] {
         &self[..]
@@ -81,7 +93,8 @@ impl<T, N> Borrow<[T]> for GenericArray<T, N>
 }
 
 impl<T, N> BorrowMut<[T]> for GenericArray<T, N>
-    where N: ArrayLength<T>
+where
+    N: ArrayLength<T>,
 {
     fn borrow_mut(&mut self) -> &mut [T] {
         &mut self[..]
@@ -89,7 +102,8 @@ impl<T, N> BorrowMut<[T]> for GenericArray<T, N>
 }
 
 impl<T, N> AsRef<[T]> for GenericArray<T, N>
-    where N: ArrayLength<T>
+where
+    N: ArrayLength<T>,
 {
     fn as_ref(&self) -> &[T] {
         &self[..]
@@ -97,7 +111,8 @@ impl<T, N> AsRef<[T]> for GenericArray<T, N>
 }
 
 impl<T, N> AsMut<[T]> for GenericArray<T, N>
-    where N: ArrayLength<T>
+where
+    N: ArrayLength<T>,
 {
     fn as_mut(&mut self) -> &mut [T] {
         &mut self[..]
@@ -105,10 +120,12 @@ impl<T, N> AsMut<[T]> for GenericArray<T, N>
 }
 
 impl<T: Hash, N> Hash for GenericArray<T, N>
-    where N: ArrayLength<T>
+where
+    N: ArrayLength<T>,
 {
     fn hash<H>(&self, state: &mut H)
-        where H: Hasher
+    where
+        H: Hasher,
     {
         Hash::hash(&self[..], state)
     }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,3 +1,5 @@
+//! `GenericArray` iterator implementation.
+
 use super::{ArrayLength, GenericArray};
 use core::cmp;
 use core::ptr;
@@ -14,7 +16,8 @@ pub struct GenericArrayIter<T, N: ArrayLength<T>> {
 }
 
 impl<T, N> IntoIterator for GenericArray<T, N>
-    where N: ArrayLength<T>
+where
+    N: ArrayLength<T>,
 {
     type Item = T;
     type IntoIter = GenericArrayIter<T, N>;
@@ -29,7 +32,8 @@ impl<T, N> IntoIterator for GenericArray<T, N>
 }
 
 impl<T, N> Drop for GenericArrayIter<T, N>
-    where N: ArrayLength<T>
+where
+    N: ArrayLength<T>,
 {
     fn drop(&mut self) {
         // Drop values that are still alive.
@@ -42,7 +46,8 @@ impl<T, N> Drop for GenericArrayIter<T, N>
 }
 
 impl<T, N> Iterator for GenericArrayIter<T, N>
-    where N: ArrayLength<T>
+where
+    N: ArrayLength<T>,
 {
     type Item = T;
 
@@ -87,7 +92,8 @@ impl<T, N> Iterator for GenericArrayIter<T, N>
 }
 
 impl<T, N> DoubleEndedIterator for GenericArrayIter<T, N>
-    where N: ArrayLength<T>
+where
+    N: ArrayLength<T>,
 {
     fn next_back(&mut self) -> Option<T> {
         if self.len() > 0 {
@@ -103,7 +109,8 @@ impl<T, N> DoubleEndedIterator for GenericArrayIter<T, N>
 }
 
 impl<T, N> ExactSizeIterator for GenericArrayIter<T, N>
-    where N: ArrayLength<T>
+where
+    N: ArrayLength<T>,
 {
     fn len(&self) -> usize {
         self.index_back - self.index

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,10 +31,12 @@
 //! assert_eq!(array[2], 3);
 //! # }
 //! ```
+
+#![deny(missing_docs)]
 #![no_std]
 pub extern crate typenum;
 extern crate nodrop;
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 extern crate serde;
 pub mod arr;
 pub mod iter;
@@ -42,15 +44,17 @@ pub use iter::GenericArrayIter;
 mod hex;
 mod impls;
 
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 pub mod impl_serde;
 
+pub mod builder;
+
+pub use self::builder::{IterableArrayLength, RecursiveArrayBuilder};
+
 use core::marker::PhantomData;
-use core::mem;
 pub use core::mem::transmute;
 use core::ops::{Deref, DerefMut};
 use core::slice;
-use nodrop::NoDrop;
 use typenum::bit::{B0, B1};
 use typenum::uint::{UInt, UTerm, Unsigned};
 
@@ -121,7 +125,8 @@ pub struct GenericArray<T, U: ArrayLength<T>> {
 }
 
 impl<T, N> Deref for GenericArray<T, N>
-    where N: ArrayLength<T>
+where
+    N: ArrayLength<T>,
 {
     type Target = [T];
 
@@ -131,7 +136,8 @@ impl<T, N> Deref for GenericArray<T, N>
 }
 
 impl<T, N> DerefMut for GenericArray<T, N>
-    where N: ArrayLength<T>
+where
+    N: ArrayLength<T>,
 {
     fn deref_mut(&mut self) -> &mut [T] {
         unsafe { slice::from_raw_parts_mut(self as *mut Self as *mut T, N::to_usize()) }
@@ -139,36 +145,99 @@ impl<T, N> DerefMut for GenericArray<T, N>
 }
 
 impl<T, N> GenericArray<T, N>
-    where N: ArrayLength<T>
+where
+    N: ArrayLength<T>,
 {
-    /// map a function over a  slice to a `GenericArray`.
-    /// The length of the slice *must* be equal to the length of the array
+    /// Initializes a new `GenericArray` instance using the given function.
+    ///
+    /// If the generator function panics while initializing the array,
+    /// any already initialized elements will be dropped.
+    #[inline]
+    pub fn generate<F>(f: F) -> GenericArray<T, N>
+    where
+        F: Fn(usize) -> T,
+    {
+        builder::generate(f)
+    }
+
+    /// Map a function over a slice to a `GenericArray`.
+    ///
+    /// The length of the slice *must* be equal to the length of the array.
+    #[inline]
     pub fn map_slice<S, F: Fn(&S) -> T>(s: &[S], f: F) -> GenericArray<T, N> {
         assert_eq!(s.len(), N::to_usize());
-        map_inner(s, f)
+
+        builder::generate(|i| f(unsafe { s.get_unchecked(i) }))
     }
 
-    /// map a function over a `GenericArray`.
+    /// Maps a `GenericArray` to another `GenericArray`.
+    ///
+    /// If the mapping function panics, any already initialized elements in the new array
+    /// will be dropped, AND any unused elements in the source array will also be dropped.
+    #[inline]
     pub fn map<U, F>(self, f: F) -> GenericArray<U, N>
-        where F: Fn(&T) -> U,
-              N: ArrayLength<U>
+    where
+        F: Fn(T) -> U,
+        N: ArrayLength<U>,
     {
-        map_inner(&self, f)
+        builder::map(self, f)
     }
 
-    /// Extracts a slice containing the entire array
+    /// Maps a `GenericArray` to another `GenericArray` by reference.
+    ///
+    /// If the mapping function panics, any already initialized elements will be dropped.
+    #[inline]
+    pub fn map_ref<U, F>(&self, f: F) -> GenericArray<U, N>
+    where
+        F: Fn(&T) -> U,
+        N: ArrayLength<U>,
+    {
+        builder::generate(|i| f(unsafe { self.get_unchecked(i) }))
+    }
+
+    /// Combines two `GenericArray` instances and iterates through both of them,
+    /// initializing a new `GenericArray` with the result of the zipped mapping function.
+    ///
+    /// If the mapping function panics, any already initialized elements in the new array
+    /// will be dropped, AND any unused elements in the source arrays will also be dropped.
+    #[inline]
+    pub fn zip<B, U, F>(self, rhs: GenericArray<B, N>, f: F) -> GenericArray<U, N>
+    where
+        F: Fn(T, B) -> U,
+        N: ArrayLength<B> + ArrayLength<U>,
+    {
+        builder::zip(self, rhs, f)
+    }
+
+    /// Combines two `GenericArray` instances and iterates through both of them by reference,
+    /// initializing a new `GenericArray` with the result of the zipped mapping function.
+    ///
+    /// If the mapping function panics, any already initialized elements will be dropped.
+    pub fn zip_ref<B, U, F>(&self, rhs: &GenericArray<B, N>, f: F) -> GenericArray<U, N>
+    where
+        F: Fn(&T, &B) -> U,
+        N: ArrayLength<B> + ArrayLength<U>,
+    {
+        builder::generate(|i| unsafe {
+            f(self.get_unchecked(i), rhs.get_unchecked(i))
+        })
+    }
+
+    /// Extracts a slice containing the entire array.
+    #[inline]
     pub fn as_slice(&self) -> &[T] {
         self.deref()
     }
 
-    /// Extracts a mutable slice containing the entire array
+    /// Extracts a mutable slice containing the entire array.
+    #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [T] {
         self.deref_mut()
     }
 
     /// Converts slice to a generic array reference with inferred length;
     ///
-    /// Length of the slice must be equal to the length of the array
+    /// Length of the slice must be equal to the length of the array.
     #[inline]
     pub fn from_slice(slice: &[T]) -> &GenericArray<T, N> {
         assert_eq!(slice.len(), N::to_usize());
@@ -177,36 +246,143 @@ impl<T, N> GenericArray<T, N>
 
     /// Converts mutable slice to a mutable generic array reference
     ///
-    /// Length of the slice must be equal to the length of the array
+    /// Length of the slice must be equal to the length of the array.
     #[inline]
     pub fn from_mut_slice(slice: &mut [T]) -> &mut GenericArray<T, N> {
         assert_eq!(slice.len(), N::to_usize());
         unsafe { &mut *(slice.as_mut_ptr() as *mut GenericArray<T, N>) }
     }
+
+    /// Recursively converts one `GenericArray` to another via the `From` trait.
+    ///
+    /// If `From::from` panics, any already initialized elements will be dropped.
+    #[inline]
+    pub fn convert<U>(self) -> GenericArray<U, N>
+    where
+        U: From<T>,
+        N: ArrayLength<U>,
+    {
+        self.map(From::from)
+    }
 }
 
-#[inline]
-fn map_inner<S, F, T, N>(list: &[S], f: F) -> GenericArray<T, N>
-    where F: Fn(&S) -> T,
-          N: ArrayLength<T>
+impl<T, N> GenericArray<T, N>
+where
+    N: IterableArrayLength<T, N>,
 {
-    unsafe {
-        let mut res: NoDrop<GenericArray<T, N>> = NoDrop::new(mem::uninitialized());
-        for (s, r) in list.iter().zip(res.iter_mut()) {
-            core::ptr::write(r, f(s))
-        }
-        res.into_inner()
+    /// Recursively initializes a new `GenericArray` instance using the given function.
+    ///
+    /// If the generator function panics while initializing the array,
+    /// any already initialized elements will be dropped.
+    #[inline]
+    pub fn generate_recursive<F>(f: F) -> GenericArray<T, N>
+    where
+        F: Fn(usize) -> T,
+    {
+        RecursiveArrayBuilder::generate(f)
+    }
+
+    /// Recursively map a function over a  slice to a `GenericArray`.
+    ///
+    /// The length of the slice *must* be equal to the length of the array.
+    ///
+    /// If the mapping function panics, any already initialized elements will be dropped.
+    #[inline]
+    pub fn map_slice_recursive<S, F: Fn(&S) -> T>(s: &[S], f: F) -> GenericArray<T, N> {
+        assert_eq!(s.len(), N::to_usize());
+
+        RecursiveArrayBuilder::generate(|i| f(unsafe { s.get_unchecked(i) }))
+    }
+
+    /// Recursively maps a `GenericArray` to another `GenericArray`.
+    ///
+    /// If the mapping function panics, any already initialized elements in the new array
+    /// will be dropped, AND any unused elements in the source array will also be dropped.
+    #[inline]
+    pub fn map_recursive<U, F>(self, f: F) -> GenericArray<U, N>
+    where
+        F: Fn(T) -> U,
+        N: IterableArrayLength<U, N>,
+    {
+        RecursiveArrayBuilder::map(self, f)
+    }
+
+    /// Recursively maps a `GenericArray` to another `GenericArray` by reference.
+    ///
+    /// If the mapping function panics, any already initialized elements will be dropped.
+    #[inline]
+    pub fn map_ref_recursive<U, F>(&self, f: F) -> GenericArray<U, N>
+    where
+        F: Fn(&T) -> U,
+        N: IterableArrayLength<U, N>,
+    {
+        RecursiveArrayBuilder::map_ref(self, f)
+    }
+
+    /// Recursively ombines two `GenericArray` instances and iterates through both of them,
+    /// initializing a new `GenericArray` with the result of the zipped mapping function.
+    ///
+    /// If the mapping function panics, any already initialized elements in the new array
+    /// will be dropped, AND any unused elements in the source arrays will also be dropped.
+    #[inline]
+    pub fn zip_recursive<B, U, F>(self, rhs: GenericArray<B, N>, f: F) -> GenericArray<U, N>
+    where
+        F: Fn(T, B) -> U,
+        N: ArrayLength<B> + IterableArrayLength<U, N>,
+    {
+        RecursiveArrayBuilder::zip(self, rhs, f)
+    }
+
+    /// Recursively combines two `GenericArray` instances and iterates through both of them by reference,
+    /// initializing a new `GenericArray` with the result of the zipped mapping function.
+    ///
+    /// If the mapping function panics, any already initialized elements will be dropped.
+    #[inline]
+    pub fn zip_ref_recursive<B, U, F>(&self, rhs: &GenericArray<B, N>, f: F) -> GenericArray<U, N>
+    where
+        F: Fn(&T, &B) -> U,
+        N: ArrayLength<B> + IterableArrayLength<U, N>,
+    {
+        RecursiveArrayBuilder::zip_ref(self, rhs, f)
+    }
+
+    /// Recursively converts one `GenericArray` to another via the `From` trait.
+    ///
+    /// If `From::from` panics, any already initialized elements will be dropped.
+    #[inline]
+    pub fn convert_recursive<U>(self) -> GenericArray<U, N>
+    where
+        U: From<T>,
+        N: IterableArrayLength<U, N>,
+    {
+        self.map_recursive(From::from)
     }
 }
 
 impl<T: Clone, N> GenericArray<T, N>
-    where N: ArrayLength<T>
+where
+    N: ArrayLength<T>,
 {
-    /// Function constructing an array from a slice by clonning its content
+    /// Construct a `GenericArray` from a slice by cloning its content
     ///
     /// Length of the slice must be equal to the length of the array
+    #[inline]
     pub fn clone_from_slice(list: &[T]) -> GenericArray<T, N> {
+        GenericArray::map_slice(list, |x: &T| x.clone())
+    }
+}
+
+impl<T: Clone, N> GenericArray<T, N>
+where
+    N: IterableArrayLength<T, N>,
+{
+    /// Recursively Construct a `GenericArray` from a slice by cloning its content
+    ///
+    /// Length of the slice must be equal to the length of the array
+    #[inline]
+    pub fn clone_from_slice_recursive(list: &[T]) -> GenericArray<T, N> {
         assert_eq!(list.len(), N::to_usize());
-        map_inner(list, |x: &T| x.clone())
+
+        GenericArray::map_slice(list, |x: &T| x.clone())
     }
 }

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -1,0 +1,76 @@
+#![no_std]
+
+#[macro_use]
+extern crate generic_array;
+
+use core::ops::Mul;
+use generic_array::GenericArray;
+use generic_array::builder::RecursiveArrayBuilder;
+
+use generic_array::typenum::U4;
+
+#[test]
+fn builder_generator() {
+    let b: GenericArray<i32, U4> = GenericArray::generate(|i| i as i32 * 4);
+
+    assert_eq!(b, arr![i32; 0, 4, 8, 12]);
+}
+
+#[test]
+fn builder_map() {
+    let b: GenericArray<i32, U4> = GenericArray::generate(|i| i as i32 * 4).map(|x| x - 3);
+
+    assert_eq!(b, arr![i32; -3, 1, 5, 9]);
+}
+
+#[test]
+fn builder_zip() {
+    let a: GenericArray<_, U4> = GenericArray::generate(|i| i + 1);
+    let b: GenericArray<_, U4> = GenericArray::generate(|i| i as i32 * 4);
+
+    let c = a.zip(b, |r, l| r as i32 + l);
+
+    assert_eq!(c, arr![i32; 1, 6, 11, 16]);
+}
+
+#[test]
+fn recursive_builder() {
+    let b = RecursiveArrayBuilder::<_, U4, _>::new()
+        .next(|| 1)
+        .next(|| 2)
+        .next(|| 3)
+        .next(|| 4)
+        .finish();
+
+    assert_eq!(b, arr![i32; 1, 2, 3, 4]);
+}
+
+#[test]
+fn recursive_generator() {
+    let b: GenericArray<i32, U4> = RecursiveArrayBuilder::generate(|i| i as i32 * 2);
+
+    assert_eq!(b, arr![i32; 0, 2, 4, 6]);
+}
+
+#[test]
+fn recursive_map() {
+    let a = arr![i32; 1, 2, 3, 4];
+
+    let b = RecursiveArrayBuilder::map_ref(&a, |x| x * 2);
+    let c = RecursiveArrayBuilder::map(a, |x| x * 3);
+
+    assert_eq!(b, arr![i32; 2, 4, 6, 8]);
+    assert_eq!(c, arr![i32; 3, 6, 9, 12]);
+}
+
+#[test]
+fn recursive_zip() {
+    let a = arr![i32; 1, 3, 5, 7];
+    let b = arr![i32; 2, 4, 6, 8];
+
+    let sum = RecursiveArrayBuilder::zip_ref(&a, &b, |lhs, rhs| *lhs + *rhs);
+    let muls = RecursiveArrayBuilder::zip(a, b, Mul::mul);
+
+    assert_eq!(sum, arr![i32; 3, 7, 11, 15]);
+    assert_eq!(muls, arr![i32; 2, 12, 30, 56]);
+}

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -74,3 +74,12 @@ fn recursive_zip() {
     assert_eq!(sum, arr![i32; 3, 7, 11, 15]);
     assert_eq!(muls, arr![i32; 2, 12, 30, 56]);
 }
+
+#[test]
+fn from_iter() {
+    use core::iter::repeat;
+
+    let a: GenericArray<_, U4> = repeat(11).take(3).collect();
+
+    assert_eq!(a, arr![i32; 11, 11, 11, 0]);
+}

--- a/tests/hex.rs
+++ b/tests/hex.rs
@@ -2,8 +2,8 @@
 extern crate generic_array;
 extern crate typenum;
 
-use std::str::from_utf8;
 use generic_array::GenericArray;
+use std::str::from_utf8;
 use typenum::U2048;
 
 

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,10 +1,11 @@
+#![recursion_limit="128"]
 #![no_std]
 #[macro_use]
 extern crate generic_array;
-use generic_array::typenum::{U1, U3, U97};
-use generic_array::GenericArray;
-use core::ops::Drop;
 use core::cell::Cell;
+use core::ops::Drop;
+use generic_array::GenericArray;
+use generic_array::typenum::{U1, U3, U97};
 
 #[test]
 fn test() {
@@ -54,9 +55,7 @@ fn test_copy() {
 
 #[test]
 fn test_iter_flat_map() {
-    assert!((0..5)
-                .flat_map(|i| arr![i32; 2 * i, 2 * i + 1])
-                .eq(0..10));
+    assert!((0..5).flat_map(|i| arr![i32; 2 * i, 2 * i + 1]).eq(0..10));
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -110,7 +109,7 @@ fn test_empty_macro() {
 // fn test_empty_macro2(){
 //     let arr = arr![];
 // }
-#[cfg(feature="serde")]
+#[cfg(feature = "serde")]
 mod impl_serde {
     extern crate serde_json;
 


### PR DESCRIPTION
I was inspired by [this StackOverflow post](https://stackoverflow.com/questions/36925673/how-can-i-initialize-an-array-using-a-function?noredirect=1&lq=1) to create a safer `GenericArray` initialization system that will drop any created or unused elements if a generator, mapping or zipping function panics.

There are two versions including in this PR, one that uses an iterative method with a position counter, and one that uses type-level recursion to effectively unroll the loops at compile-time and avoiding the counters.

Depending on how smart LLVM is, both methods are probably about the same for mid-sized arrays (20 elements or so), but the compile-time type-level recursion should be faster for shorter arrays  (<5 elements), and the iterative runtime version should be better for larger arrays (100+ elements).

The type-level recursion one tends to complain about recursion limits, even if it is inlined for simple operations, but especially for short arrays with operations that can't panic LLVM is smart enough to inline everything into single operations sometimes.

So each has their tradeoffs, and I've tried to present them both as well as possible.

I've also added some better documentation and ran `rustfmt` on the files, which shouldn't be that big of a deal.

If there is anything you would like me to change, feel free to suggest it.