### PR TITLE
Add `GenericSequence`, `Lengthen`, `Shorten`, `Split` and `Concat` traits.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,15 +54,16 @@ use core::{mem, ptr, slice};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
 pub use core::mem::transmute;
-use core::ops::{Deref, DerefMut, Add, Sub};
+use core::ops::{Deref, DerefMut};
 
 use typenum::bit::{B0, B1};
-use typenum::operator_aliases::{Add1, Sub1};
 use typenum::uint::{UInt, UTerm, Unsigned};
 
 #[cfg_attr(test, macro_use)]
 pub mod arr;
 pub mod iter;
+pub mod sequence;
+
 pub use iter::GenericArrayIter;
 
 /// Trait making `GenericArray` work, marking types to be used as length of an array
@@ -74,126 +75,6 @@ pub unsafe trait ArrayLength<T>: Unsigned {
 unsafe impl<T> ArrayLength<T> for UTerm {
     #[doc(hidden)]
     type ArrayType = ();
-}
-
-/// Defines some `GenericArray` sequence with an associated length.
-///
-/// This is useful for passing N-length generic arrays as generics.
-pub unsafe trait GenericSequence<T>: Sized {
-    /// `GenericArray` associated length
-    type Length: ArrayLength<T>;
-}
-
-unsafe impl<T, N: ArrayLength<T>> GenericSequence<T> for GenericArray<T, N> {
-    type Length = N;
-}
-
-/// Defines any `GenericSequence` which can be lengthened or extended by appending
-/// an element to the end of it.
-///
-/// Any lengthened sequence can be shortened back to the original
-/// by removed the last element.
-pub unsafe trait Lengthen<T>: GenericSequence<T> {
-    /// `GenericSequence` that has one more element than `Self`
-    type Longer: Shorten<T, Shorter=Self>;
-
-    /// Moves all the current elements into a new array with one more element than the current one.
-    ///
-    /// The last element of the new array is set to `last`
-    ///
-    /// Example:
-    ///
-    /// ```ignore
-    /// let a = arr![i32; 1, 2, 3, 4];
-    /// let b = arr![i32; 1, 2, 3];
-    ///
-    /// assert_eq!(a, b.lengthen(4));
-    /// ```
-    fn lengthen(self, last: T) -> Self::Longer;
-}
-
-/// Defines a `GenericSequence` which can be shortened by removing the last element in it.
-///
-/// Additionally, any shortened sequence can be lengthened by
-/// adding an element to the end of it.
-pub unsafe trait Shorten<T>: GenericSequence<T> {
-    /// `GenericSequence` that has one less element than `Self`
-    type Shorter: Lengthen<T, Longer=Self>;
-
-    /// Moves all but the last element into a `GenericArray` with one
-    /// less element than the current one.
-    ///
-    /// Example:
-    ///
-    /// ```ignore
-    /// let a = arr![i32; 1, 2, 3, 4];
-    /// let b = arr![i32; 1, 2, 3];
-    ///
-    /// let (init, last) = a.shorten();
-    ///
-    /// assert_eq!(init, b);
-    /// assert_eq!(last, 4);
-    /// ```
-    fn shorten(self) -> (Self::Shorter, T);
-}
-
-unsafe impl<T, N: ArrayLength<T>> Lengthen<T> for GenericArray<T, N>
-where
-    N: Add<B1>,
-    Add1<N>: ArrayLength<T>,
-    Add1<N>: Sub<B1, Output=N>,
-    Sub1<Add1<N>>: ArrayLength<T>
-{
-    type Longer = GenericArray<T, Add1<N>>;
-
-    fn lengthen(self, last: T) -> Self::Longer {
-        let mut longer: ManuallyDrop<GenericArray<T, Add1<N>>> =
-            ManuallyDrop::new(unsafe { mem::uninitialized() });
-
-        for (dst, src) in longer.iter_mut().zip(self.iter()) {
-            unsafe {
-                ptr::write(dst, ptr::read(src));
-            }
-        }
-
-        unsafe {
-            ptr::write(&mut longer[N::to_usize()], last);
-        }
-
-        mem::forget(self);
-
-        ManuallyDrop::into_inner(longer)
-    }
-}
-
-
-unsafe impl<T, N: ArrayLength<T>> Shorten<T> for GenericArray<T, N>
-where
-    N: Sub<B1>,
-    Sub1<N>: ArrayLength<T>,
-    Sub1<N>: Add<B1, Output=N>,
-    Add1<Sub1<N>>: ArrayLength<T>,
-{
-    type Shorter = GenericArray<T, Sub1<N>>;
-
-    fn shorten(self) -> (Self::Shorter, T) {
-        let mut shorter: ManuallyDrop<GenericArray<T, Sub1<N>>> =
-            ManuallyDrop::new(unsafe { mem::uninitialized() });
-
-        for (dst, src) in shorter.iter_mut().zip(self.iter()) {
-            unsafe {
-                ptr::write(dst, ptr::read(src));
-            }
-        }
-
-        // Move out last element
-        let last = unsafe { ptr::read(&self[N::to_usize() - 1]) };
-
-        // Forget all moved elements before the last one is dropped
-        mem::forget(self);
-
-        (ManuallyDrop::into_inner(shorter), last)
-    }
 }
 
 /// Internal type used to generate a struct of appropriate size

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -79,15 +79,14 @@ where
     type Longer = GenericArray<T, Add1<N>>;
 
     fn lengthen(self, last: T) -> Self::Longer {
-        let mut longer: ManuallyDrop<GenericArray<T, Add1<N>>> =
-            ManuallyDrop::new(unsafe { mem::uninitialized() });
+        let mut longer: Self::Longer = unsafe { mem::uninitialized() };
 
         unsafe {
             ptr::write(longer.as_mut_ptr() as *mut _, self);
             ptr::write(&mut longer[N::to_usize()], last);
         }
 
-        ManuallyDrop::into_inner(longer)
+        longer
     }
 }
 

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -1,0 +1,181 @@
+//! Useful traits for manipulating sequences of data stored in `GenericArray`s
+#![allow(missing_docs)]
+
+use super::*;
+use core::{mem, ptr};
+use core::ops::{Add, Sub};
+use typenum::consts::*;
+use typenum::marker_traits::*;
+use typenum::operator_aliases::*;
+
+/// Defines some `GenericArray` sequence with an associated length.
+///
+/// This is useful for passing N-length generic arrays as generics.
+pub unsafe trait GenericSequence<T>: Sized {
+    /// `GenericArray` associated length
+    type Length: ArrayLength<T>;
+}
+
+unsafe impl<T, N: ArrayLength<T>> GenericSequence<T> for GenericArray<T, N> {
+    type Length = N;
+}
+
+/// Defines any `GenericSequence` which can be lengthened or extended by appending
+/// an element to the end of it.
+///
+/// Any lengthened sequence can be shortened back to the original
+/// by removed the last element.
+pub unsafe trait Lengthen<T>: GenericSequence<T> {
+    /// `GenericSequence` that has one more element than `Self`
+    type Longer: Shorten<T, Shorter = Self>;
+
+    /// Moves all the current elements into a new array with one more element than the current one.
+    ///
+    /// The last element of the new array is set to `last`
+    ///
+    /// Example:
+    ///
+    /// ```ignore
+    /// let a = arr![i32; 1, 2, 3, 4];
+    /// let b = arr![i32; 1, 2, 3];
+    ///
+    /// assert_eq!(a, b.lengthen(4));
+    /// ```
+    fn lengthen(self, last: T) -> Self::Longer;
+}
+
+/// Defines a `GenericSequence` which can be shortened by removing the last element in it.
+///
+/// Additionally, any shortened sequence can be lengthened by
+/// adding an element to the end of it.
+pub unsafe trait Shorten<T>: GenericSequence<T> {
+    /// `GenericSequence` that has one less element than `Self`
+    type Shorter: Lengthen<T, Longer = Self>;
+
+    /// Moves all but the last element into a `GenericArray` with one
+    /// less element than the current one.
+    ///
+    /// Example:
+    ///
+    /// ```ignore
+    /// let a = arr![i32; 1, 2, 3, 4];
+    /// let b = arr![i32; 1, 2, 3];
+    ///
+    /// let (init, last) = a.shorten();
+    ///
+    /// assert_eq!(init, b);
+    /// assert_eq!(last, 4);
+    /// ```
+    fn shorten(self) -> (Self::Shorter, T);
+}
+
+unsafe impl<T, N: ArrayLength<T>> Lengthen<T> for GenericArray<T, N>
+where
+    N: Add<B1>,
+    Add1<N>: ArrayLength<T>,
+    Add1<N>: Sub<B1, Output = N>,
+    Sub1<Add1<N>>: ArrayLength<T>,
+{
+    type Longer = GenericArray<T, Add1<N>>;
+
+    fn lengthen(self, last: T) -> Self::Longer {
+        let mut longer: ManuallyDrop<GenericArray<T, Add1<N>>> =
+            ManuallyDrop::new(unsafe { mem::uninitialized() });
+
+        unsafe {
+            ptr::write(longer.as_mut_ptr() as *mut _, self);
+            ptr::write(&mut longer[N::to_usize()], last);
+        }
+
+        ManuallyDrop::into_inner(longer)
+    }
+}
+
+
+unsafe impl<T, N: ArrayLength<T>> Shorten<T> for GenericArray<T, N>
+where
+    N: Sub<B1>,
+    Sub1<N>: ArrayLength<T>,
+    Sub1<N>: Add<B1, Output = N>,
+    Add1<Sub1<N>>: ArrayLength<T>,
+{
+    type Shorter = GenericArray<T, Sub1<N>>;
+
+    fn shorten(self) -> (Self::Shorter, T) {
+        let head_ptr = self.as_ptr();
+        let last_ptr = unsafe { head_ptr.offset(Sub1::<N>::to_usize() as isize) };
+
+        let head = unsafe { ptr::read(head_ptr as _) };
+        let last = unsafe { ptr::read(last_ptr as _) };
+
+        mem::forget(self);
+
+        (head, last)
+    }
+}
+
+pub unsafe trait Split<T, K>: GenericSequence<T>
+where
+    K: ArrayLength<T>,
+{
+    type Head: GenericSequence<T>;
+    type Tail: GenericSequence<T>;
+
+    fn split(self) -> (Self::Head, Self::Tail);
+}
+
+unsafe impl<T, N, K> Split<T, K> for GenericArray<T, N>
+where
+    N: ArrayLength<T>,
+    K: ArrayLength<T>,
+    N: Sub<K>,
+    Diff<N, K>: ArrayLength<T>,
+{
+    type Head = GenericArray<T, K>;
+    type Tail = GenericArray<T, Diff<N, K>>;
+
+    fn split(self) -> (Self::Head, Self::Tail) {
+        let head_ptr = self.as_ptr();
+        let tail_ptr = unsafe { head_ptr.offset(K::to_usize() as isize) };
+
+        let head = unsafe { ptr::read(head_ptr as _) };
+        let tail = unsafe { ptr::read(tail_ptr as _) };
+
+        mem::forget(self);
+
+        (head, tail)
+    }
+}
+
+pub unsafe trait Concat<T, M>: GenericSequence<T>
+where
+    M: ArrayLength<T>,
+{
+    type Rest: GenericSequence<T, Length = M>;
+    type Output: GenericSequence<T>;
+
+    fn concat(self, rest: Self::Rest) -> Self::Output;
+}
+
+unsafe impl<T, N, M> Concat<T, M> for GenericArray<T, N>
+where
+    N: ArrayLength<T> + Add<M>,
+    M: ArrayLength<T>,
+    Sum<N, M>: ArrayLength<T>,
+{
+    type Rest = GenericArray<T, M>;
+    type Output = GenericArray<T, Sum<N, M>>;
+
+    fn concat(self, rest: Self::Rest) -> Self::Output {
+        let mut output: Self::Output = unsafe { mem::uninitialized() };
+
+        let output_ptr = output.as_mut_ptr();
+
+        unsafe {
+            ptr::write(output_ptr as *mut _, self);
+            ptr::write(output_ptr.offset(N::to_usize() as isize) as *mut _, rest);
+        }
+
+        output
+    }
+}

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -162,12 +162,12 @@ where
     K: ArrayLength<T>,
 {
     /// First part of the resulting split array
-    type Head: GenericSequence<T>;
+    type First: GenericSequence<T>;
     /// Second part of the resulting split array
-    type Tail: GenericSequence<T>;
+    type Second: GenericSequence<T>;
 
-    /// Splits an array at the given index, returning the head and tail arrays.
-    fn split(self) -> (Self::Head, Self::Tail);
+    /// Splits an array at the given index, returning the separate parts of the array.
+    fn split(self) -> (Self::First, Self::Second);
 }
 
 unsafe impl<T, N, K> Split<T, K> for GenericArray<T, N>
@@ -177,10 +177,10 @@ where
     N: Sub<K>,
     Diff<N, K>: ArrayLength<T>,
 {
-    type Head = GenericArray<T, K>;
-    type Tail = GenericArray<T, Diff<N, K>>;
+    type First = GenericArray<T, K>;
+    type Second = GenericArray<T, Diff<N, K>>;
 
-    fn split(self) -> (Self::Head, Self::Tail) {
+    fn split(self) -> (Self::First, Self::Second) {
         let head_ptr = self.as_ptr();
         let tail_ptr = unsafe { head_ptr.offset(K::to_usize() as isize) };
 

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -4,7 +4,7 @@
 extern crate generic_array;
 use core::cell::Cell;
 use core::ops::Drop;
-use generic_array::GenericArray;
+use generic_array::{GenericArray, Shorten, Lengthen};
 use generic_array::typenum::{U1, U3, U4, U97};
 
 #[test]
@@ -166,4 +166,45 @@ fn test_from_iter() {
     let a: GenericArray<_, U4> = repeat(11).take(3).collect();
 
     assert_eq!(a, arr![i32; 11, 11, 11, 0]);
+}
+
+#[test]
+fn test_sizes() {
+    #![allow(dead_code)]
+    use core::mem::{size_of, size_of_val};
+
+    #[derive(Debug)]
+    #[repr(C)]
+    #[repr(packed)]
+    #[derive(Default)]
+    struct Test {
+        t: u16,
+        s: u32,
+        r: u16,
+        f: u16,
+        o: u32,
+    }
+
+    assert_eq!(size_of::<Test>(), 14);
+
+    assert_eq!(size_of_val(&arr![u8; 1, 2, 3]), size_of::<u8>() * 3);
+    assert_eq!(size_of_val(&arr![u32; 1]), size_of::<u32>() * 1);
+    assert_eq!(size_of_val(&arr![u64; 1, 2, 3, 4]), size_of::<u64>() * 4);
+
+    assert_eq!(size_of::<GenericArray<Test, U97>>(), size_of::<Test>() * 97);
+}
+
+#[test]
+fn test_resize() {
+    let a = arr![i32; 1, 2, 3, 4];
+    let b = arr![i32; 1, 2, 3];
+
+    let (init, last) = a.shorten();
+
+    assert_eq!(init, b);
+    assert_eq!(last, 4);
+
+    let c = init.lengthen(5);
+
+    assert_eq!(c, arr![i32; 1, 2, 3, 5]);
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -4,7 +4,8 @@
 extern crate generic_array;
 use core::cell::Cell;
 use core::ops::Drop;
-use generic_array::{GenericArray, Shorten, Lengthen};
+use generic_array::GenericArray;
+use generic_array::sequence::*;
 use generic_array::typenum::{U1, U3, U4, U97};
 
 #[test]
@@ -207,4 +208,30 @@ fn test_resize() {
     let c = init.lengthen(5);
 
     assert_eq!(c, arr![i32; 1, 2, 3, 5]);
+
+    let d = init.shorten().0.lengthen(1)
+                .shorten().0.lengthen(2)
+                .shorten().0.lengthen(34);
+
+    assert_eq!(d, arr![i32; 1, 2, 34]);
+}
+
+#[test]
+fn test_split() {
+    let a = arr![i32; 1, 2, 3, 4];
+
+    let (b, c) = a.split();
+
+    assert_eq!(b, arr![i32; 1]);
+    assert_eq!(c, arr![i32; 2, 3, 4]);
+
+    let (e, f) = a.split();
+
+    assert_eq!(e, arr![i32; 1, 2]);
+    assert_eq!(f, arr![i32; 3, 4]);
+}
+
+#[test]
+fn test_concat() {
+
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -196,24 +196,36 @@ fn test_sizes() {
 }
 
 #[test]
-fn test_resize() {
+fn test_append() {
+    let a = arr![i32; 1, 2, 3];
+
+    let b = a.append(4);
+
+    assert_eq!(b, arr![i32; 1, 2, 3, 4]);
+}
+
+#[test]
+fn test_prepend() {
+    let a = arr![i32; 1, 2, 3];
+
+    let b = a.prepend(4);
+
+    assert_eq!(b, arr![i32; 4, 1, 2, 3]);
+}
+
+#[test]
+fn test_pop() {
     let a = arr![i32; 1, 2, 3, 4];
-    let b = arr![i32; 1, 2, 3];
 
-    let (init, last) = a.shorten();
+    let (init, last) = a.pop_back();
 
-    assert_eq!(init, b);
+    assert_eq!(init, arr![i32; 1, 2, 3]);
     assert_eq!(last, 4);
 
-    let c = init.lengthen(5);
+    let (head, tail) = a.pop_front();
 
-    assert_eq!(c, arr![i32; 1, 2, 3, 5]);
-
-    let d = init.shorten().0.lengthen(1)
-                .shorten().0.lengthen(2)
-                .shorten().0.lengthen(34);
-
-    assert_eq!(d, arr![i32; 1, 2, 34]);
+    assert_eq!(head, 1);
+    assert_eq!(tail, arr![i32; 2, 3, 4]);
 }
 
 #[test]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -233,5 +233,15 @@ fn test_split() {
 
 #[test]
 fn test_concat() {
+    let a = arr![i32; 1, 2];
+    let b = arr![i32; 3, 4];
 
+    let c = a.concat(b);
+
+    assert_eq!(c, arr![i32; 1, 2, 3, 4]);
+
+    let (d, e) = c.split();
+
+    assert_eq!(d, arr![i32; 1]);
+    assert_eq!(e, arr![i32; 2, 3, 4]);
 }


### PR DESCRIPTION
Here are some more useful features that allow for easier passing of `GenericArray` via generics, as well as some simple resize methods implemented as inverse traits. I've had to use these a few times already.

These really should have been in that last pull request, but I wasn't far enough along in a dependent project to really test it.