### PR TITLE
redefine `transmute` to avert errors when compiler can't prove equal sizes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,6 @@ use core::{mem, ptr, slice};
 
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
-pub use core::mem::transmute;
 use core::ops::{Deref, DerefMut};
 
 use typenum::bit::{B0, B1};
@@ -433,6 +432,13 @@ where
 
         destination.into_inner()
     }
+}
+
+#[inline]
+pub unsafe fn transmute<A, B>(a: A) -> B {
+    let b = ::core::ptr::read(&a as *const A as *const B);
+    ::core::mem::forget(a);
+    b
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Else the compiler fails in some cases when using `arr` macro with a type parametre.