### PR TITLE
Functional system redesign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.rlib
 *.dll
 
+.vscode
+
 # Executables
 *.exe
 

--- a/src/functional.rs
+++ b/src/functional.rs
@@ -46,7 +46,7 @@ pub unsafe trait FunctionalSequence<T>: GenericSequence<T> {
     where
         Self: MappedGenericSequence<T, U>,
         Self::Length: ArrayLength<U>,
-        F: FnMut(SequenceItem<Self>) -> U,
+        F: FnMut(Self::Item) -> U,
     {
         FromIterator::from_iter(self.into_iter().map(f))
     }
@@ -63,7 +63,7 @@ pub unsafe trait FunctionalSequence<T>: GenericSequence<T> {
         Rhs: MappedGenericSequence<B, U, Mapped=MappedSequence<Self, T, U>>,
         Self::Length: ArrayLength<B> + ArrayLength<U>,
         Rhs: GenericSequence<B, Length=Self::Length>,
-        F: FnMut(SequenceItem<Self>, SequenceItem<Rhs>) -> U,
+        F: FnMut(Self::Item, Rhs::Item) -> U,
     {
         rhs.inverted_zip2(self, f)
     }
@@ -73,7 +73,7 @@ pub unsafe trait FunctionalSequence<T>: GenericSequence<T> {
     /// If the fold function panics, any unused elements will be dropped.
     fn fold<U, F>(self, init: U, f: F) -> U
     where
-        F: FnMut(U, SequenceItem<Self>) -> U,
+        F: FnMut(U, Self::Item) -> U,
     {
         self.into_iter().fold(init, f)
     }

--- a/src/functional.rs
+++ b/src/functional.rs
@@ -43,10 +43,10 @@ pub unsafe trait FunctionalSequence<T>: GenericSequence<T> {
     /// If the mapping function panics, any already initialized elements in the new sequence
     /// will be dropped, AND any unused elements in the source sequence will also be dropped.
     fn map<U, F>(self, f: F) -> MappedSequence<Self, T, U>
-        where
-            Self: MappedGenericSequence<T, U>,
-            Self::Length: ArrayLength<U>,
-            F: FnMut(SequenceItem<Self>) -> U,
+    where
+        Self: MappedGenericSequence<T, U>,
+        Self::Length: ArrayLength<U>,
+        F: FnMut(SequenceItem<Self>) -> U,
     {
         FromIterator::from_iter(self.into_iter().map(f))
     }
@@ -58,14 +58,24 @@ pub unsafe trait FunctionalSequence<T>: GenericSequence<T> {
     /// will be dropped, AND any unused elements in the source sequences will also be dropped.
     #[inline]
     fn zip<B, Rhs, U, F>(self, rhs: Rhs, f: F) -> MappedSequence<Self, T, U>
-        where
-            Self: MappedGenericSequence<T, U>,
-            Rhs: MappedGenericSequence<B, U, Mapped=MappedSequence<Self, T, U>>,
-            Self::Length: ArrayLength<B> + ArrayLength<U>,
-            Rhs: GenericSequence<B, Length=Self::Length>,
-            F: FnMut(SequenceItem<Self>, SequenceItem<Rhs>) -> U,
+    where
+        Self: MappedGenericSequence<T, U>,
+        Rhs: MappedGenericSequence<B, U, Mapped=MappedSequence<Self, T, U>>,
+        Self::Length: ArrayLength<B> + ArrayLength<U>,
+        Rhs: GenericSequence<B, Length=Self::Length>,
+        F: FnMut(SequenceItem<Self>, SequenceItem<Rhs>) -> U,
     {
         rhs.inverted_zip2(self, f)
+    }
+
+    /// Folds (or reduces) a sequence of data into a single value.
+    ///
+    /// If the fold function panics, any unused elements will be dropped.
+    fn fold<U, F>(self, init: U, f: F) -> U
+    where
+        F: FnMut(U, SequenceItem<Self>) -> U,
+    {
+        self.into_iter().fold(init, f)
     }
 }
 

--- a/src/functional.rs
+++ b/src/functional.rs
@@ -50,8 +50,9 @@ pub unsafe trait FunctionalSequence<T>: GenericSequence<T> {
     fn zip<B, Rhs, U, F>(self, rhs: Rhs, mut f: F) -> MappedSequence<Self, T, U>
         where
             Self: MappedGenericSequence<T, U>,
+            Rhs: MappedGenericSequence<B, U, Mapped=MappedSequence<Self, T, U>>,
             Self::Length: ArrayLength<B> + ArrayLength<U>,
-            Rhs: GenericSequence<B>,
+            Rhs: GenericSequence<B, Length=Self::Length>,
             F: FnMut(SequenceItem<Self>, SequenceItem<Rhs>) -> U,
     {
         FromIterator::from_iter(self.into_iter().zip(rhs.into_iter()).map(|(l, r)| f(l, r) ))

--- a/src/functional.rs
+++ b/src/functional.rs
@@ -1,0 +1,69 @@
+//! Functional programming with generic sequences
+
+use core::iter::FromIterator;
+
+use super::ArrayLength;
+use sequence::*;
+
+/// Defines the relationship between one generic sequence and another,
+/// for operations such as `map` and `zip`.
+pub unsafe trait MappedGenericSequence<T, U>: GenericSequence<T>
+where
+    Self::Length: ArrayLength<U>,
+{
+    /// Mapped sequence type
+    type Mapped: GenericSequence<U, Length=Self::Length>;
+}
+
+unsafe impl<'a, T, U, S: MappedGenericSequence<T, U>> MappedGenericSequence<T, U> for &'a S
+where
+    &'a S: GenericSequence<T>,
+    S: GenericSequence<T, Length=<&'a S as GenericSequence<T>>::Length>,
+    <S as GenericSequence<T>>::Length: ArrayLength<U>,
+{
+    type Mapped = <S as MappedGenericSequence<T, U>>::Mapped;
+}
+
+/// Accessor type for a mapped generic sequence
+pub type MappedSequence<S, T, U> = <<S as MappedGenericSequence<T, U>>::Mapped as GenericSequence<U>>::Sequence;
+
+/// Defines functional programming methods for generic sequences
+pub unsafe trait FunctionalSequence<T>: GenericSequence<T> {
+    /// Maps a `GenericSequence` to another `GenericSequence`.
+    ///
+    /// If the mapping function panics, any already initialized elements in the new sequence
+    /// will be dropped, AND any unused elements in the source sequence will also be dropped.
+    fn map<U, F>(self, f: F) -> MappedSequence<Self, T, U>
+        where
+            Self: MappedGenericSequence<T, U>,
+            Self::Length: ArrayLength<U>,
+            F: Fn(SequenceItem<Self>) -> U,
+    {
+        FromIterator::from_iter(self.into_iter().map(f))
+    }
+
+    /// Combines two `GenericSequence` instances and iterates through both of them,
+    /// initializing a new `GenericSequence` with the result of the zipped mapping function.
+    ///
+    /// If the mapping function panics, any already initialized elements in the new sequence
+    /// will be dropped, AND any unused elements in the source sequences will also be dropped.
+    fn zip<B, Rhs, U, F>(self, rhs: Rhs, f: F) -> MappedSequence<Self, T, U>
+        where
+            Self: MappedGenericSequence<T, U>,
+            Self::Length: ArrayLength<B> + ArrayLength<U>,
+            Rhs: GenericSequence<B>,
+            F: Fn(SequenceItem<Self>, SequenceItem<Rhs>) -> U,
+    {
+        FromIterator::from_iter(self.into_iter().zip(rhs.into_iter()).map(|(l, r)| f(l, r) ))
+    }
+}
+
+unsafe impl<'a, T, S: GenericSequence<T>> FunctionalSequence<T> for &'a S
+where
+    &'a S: GenericSequence<T>,
+{}
+
+unsafe impl<'a, T, S: GenericSequence<T>> FunctionalSequence<T> for &'a mut S
+where
+    &'a mut S: GenericSequence<T>,
+{}

--- a/src/functional.rs
+++ b/src/functional.rs
@@ -37,7 +37,7 @@ pub unsafe trait FunctionalSequence<T>: GenericSequence<T> {
         where
             Self: MappedGenericSequence<T, U>,
             Self::Length: ArrayLength<U>,
-            F: Fn(SequenceItem<Self>) -> U,
+            F: FnMut(SequenceItem<Self>) -> U,
     {
         FromIterator::from_iter(self.into_iter().map(f))
     }
@@ -47,12 +47,12 @@ pub unsafe trait FunctionalSequence<T>: GenericSequence<T> {
     ///
     /// If the mapping function panics, any already initialized elements in the new sequence
     /// will be dropped, AND any unused elements in the source sequences will also be dropped.
-    fn zip<B, Rhs, U, F>(self, rhs: Rhs, f: F) -> MappedSequence<Self, T, U>
+    fn zip<B, Rhs, U, F>(self, rhs: Rhs, mut f: F) -> MappedSequence<Self, T, U>
         where
             Self: MappedGenericSequence<T, U>,
             Self::Length: ArrayLength<B> + ArrayLength<U>,
             Rhs: GenericSequence<B>,
-            F: Fn(SequenceItem<Self>, SequenceItem<Rhs>) -> U,
+            F: FnMut(SequenceItem<Self>, SequenceItem<Rhs>) -> U,
     {
         FromIterator::from_iter(self.into_iter().zip(rhs.into_iter()).map(|(l, r)| f(l, r) ))
     }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -1,8 +1,11 @@
-use super::{ArrayLength, GenericArray};
 use core::borrow::{Borrow, BorrowMut};
 use core::cmp::Ordering;
 use core::fmt::{self, Debug};
 use core::hash::{Hash, Hasher};
+
+use super::{ArrayLength, GenericArray};
+use sequence::*;
+use functional::*;
 
 impl<T: Default, N> Default for GenericArray<T, N>
 where
@@ -19,7 +22,7 @@ where
     N: ArrayLength<T>,
 {
     fn clone(&self) -> GenericArray<T, N> {
-        self.map_ref(|x| x.clone())
+        self.map(|x| x.clone())
     }
 }
 

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -14,6 +14,9 @@ pub struct GenericArrayIter<T, N: ArrayLength<T>> {
     index_back: usize,
 }
 
+unsafe impl<T: Send, N: ArrayLength<T>> Send for GenericArrayIter<T, N> {}
+unsafe impl<T: Sync, N: ArrayLength<T>> Sync for GenericArrayIter<T, N> {}
+
 impl<T, N> IntoIterator for GenericArray<T, N>
 where
     N: ArrayLength<T>,
@@ -34,6 +37,7 @@ impl<T, N> Drop for GenericArrayIter<T, N>
 where
     N: ArrayLength<T>,
 {
+    #[inline]
     fn drop(&mut self) {
         // Drop values that are still alive.
         for p in &mut self.array[self.index..self.index_back] {
@@ -50,23 +54,28 @@ where
 {
     type Item = T;
 
+    #[inline]
     fn next(&mut self) -> Option<T> {
-        if self.len() > 0 {
-            unsafe {
-                let p = self.array.get_unchecked(self.index);
-                self.index += 1;
-                Some(ptr::read(p))
-            }
+        if self.index < self.index_back {
+            let p = unsafe {
+                Some(ptr::read(self.array.get_unchecked(self.index)))
+            };
+
+            self.index += 1;
+
+            p
         } else {
             None
         }
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.len();
         (len, Some(len))
     }
 
+    #[inline]
     fn count(self) -> usize {
         self.len()
     }
@@ -95,11 +104,11 @@ where
     N: ArrayLength<T>,
 {
     fn next_back(&mut self) -> Option<T> {
-        if self.len() > 0 {
+        if self.index < self.index_back {
             self.index_back -= 1;
+
             unsafe {
-                let p = self.array.get_unchecked(self.index_back);
-                Some(ptr::read(p))
+                Some(ptr::read(self.array.get_unchecked(self.index_back)))
             }
         } else {
             None

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,7 +330,7 @@ where
         Lhs: GenericSequence<B, Length=Self::Length> + MappedGenericSequence<B, U>,
         Self: MappedGenericSequence<T, U>,
         Self::Length: ArrayLength<B> + ArrayLength<U>,
-        F: FnMut(SequenceItem<Lhs>, SequenceItem<Self>) -> U
+        F: FnMut(Lhs::Item, Self::Item) -> U
     {
         let mut right = ArrayConsumer::new(self);
 
@@ -385,7 +385,7 @@ where
         Rhs: MappedGenericSequence<B, U, Mapped=MappedSequence<Self, T, U>>,
         Self::Length: ArrayLength<B> + ArrayLength<U>,
         Rhs: GenericSequence<B, Length=Self::Length>,
-        F: FnMut(T, SequenceItem<Rhs>) -> U,
+        F: FnMut(T, Rhs::Item) -> U,
     {
         rhs.inverted_zip(self, f)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,9 +281,9 @@ where
     type Length = N;
     type Sequence = Self;
 
-    fn generate<F>(f: F) -> GenericArray<T, N>
+    fn generate<F>(mut f: F) -> GenericArray<T, N>
     where
-        F: Fn(usize) -> T,
+        F: FnMut(usize) -> T,
     {
         let mut destination = ArrayBuilder::new();
 
@@ -312,11 +312,11 @@ where
     N: ArrayLength<T>,
     Self: GenericSequence<T, Item=T>
 {
-    fn map<U, F>(self, f: F) -> MappedSequence<Self, T, U>
+    fn map<U, F>(self, mut f: F) -> MappedSequence<Self, T, U>
     where
         Self::Length: ArrayLength<U>,
         Self: MappedGenericSequence<T, U>,
-        F: Fn(T) -> U,
+        F: FnMut(T) -> U,
     {
         let mut source = ArrayConsumer::new(self);
 
@@ -331,12 +331,12 @@ where
         }))
     }
 
-    fn zip<B, Rhs, U, F>(self, rhs: Rhs, f: F) -> MappedSequence<Self, T, U>
+    fn zip<B, Rhs, U, F>(self, rhs: Rhs, mut f: F) -> MappedSequence<Self, T, U>
     where
         Self: MappedGenericSequence<T, U>,
         Self::Length: ArrayLength<B> + ArrayLength<U>,
         Rhs: GenericSequence<B>,
-        F: Fn(T, SequenceItem<Rhs>) -> U,
+        F: FnMut(T, SequenceItem<Rhs>) -> U,
     {
         let mut left = ArrayConsumer::new(self);
 

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -45,6 +45,17 @@ pub unsafe trait GenericSequence<T>: Sized + IntoIterator {
             f(left_value, right_value)
         }))
     }
+
+    #[doc(hidden)]
+    fn inverted_zip2<B, Lhs, U, F>(self, lhs: Lhs, mut f: F) -> MappedSequence<Lhs, B, U>
+    where
+        Lhs: GenericSequence<B, Length=Self::Length> + MappedGenericSequence<B, U>,
+        Self: MappedGenericSequence<T, U>,
+        Self::Length: ArrayLength<B> + ArrayLength<U>,
+        F: FnMut(SequenceItem<Lhs>, SequenceItem<Self>) -> U
+    {
+        FromIterator::from_iter(lhs.into_iter().zip(self.into_iter()).map(|(l, r)| f(l, r) ))
+    }
 }
 
 /// Accessor type for iteration items from `GenericSequence`

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -52,14 +52,11 @@ pub unsafe trait GenericSequence<T>: Sized + IntoIterator {
         Lhs: GenericSequence<B, Length=Self::Length> + MappedGenericSequence<B, U>,
         Self: MappedGenericSequence<T, U>,
         Self::Length: ArrayLength<B> + ArrayLength<U>,
-        F: FnMut(SequenceItem<Lhs>, SequenceItem<Self>) -> U
+        F: FnMut(Lhs::Item, Self::Item) -> U
     {
         FromIterator::from_iter(lhs.into_iter().zip(self.into_iter()).map(|(l, r)| f(l, r) ))
     }
 }
-
-/// Accessor type for iteration items from `GenericSequence`
-pub type SequenceItem<S> = <S as IntoIterator>::Item;
 
 unsafe impl<'a, T: 'a, S: GenericSequence<T>> GenericSequence<T> for &'a S
 where

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -20,7 +20,7 @@ pub unsafe trait GenericSequence<T>: Sized + IntoIterator {
     /// If the generator function panics while initializing the sequence,
     /// any already initialized elements will be dropped.
     fn generate<F>(f: F) -> Self::Sequence
-        where F: Fn(usize) -> T;
+        where F: FnMut(usize) -> T;
 }
 
 /// Accessor type for iteration items from `GenericSequence`
@@ -35,7 +35,7 @@ where
 
     #[inline]
     fn generate<F>(f: F) -> Self::Sequence
-        where F: Fn(usize) -> T
+        where F: FnMut(usize) -> T
     {
         S::generate(f)
     }
@@ -50,7 +50,7 @@ where
 
     #[inline]
     fn generate<F>(f: F) -> Self::Sequence
-        where F: Fn(usize) -> T
+        where F: FnMut(usize) -> T
     {
         S::generate(f)
     }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -279,8 +279,8 @@ fn test_fold() {
 fn sum_generic<S>(s: S) -> i32
 where
     S: FunctionalSequence<i32>,
-    SequenceItem<S>: Add<i32, Output=i32>, // `+`
-    i32: Add<SequenceItem<S>, Output=i32>, // reflexive
+    S::Item: Add<i32, Output=i32>, // `+`
+    i32: Add<S::Item, Output=i32>, // reflexive
 {
     s.fold(0, |a, x| a + x)
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -3,7 +3,7 @@
 #[macro_use]
 extern crate generic_array;
 use core::cell::Cell;
-use core::ops::Drop;
+use core::ops::{Add, Drop};
 use generic_array::GenericArray;
 use generic_array::sequence::*;
 use generic_array::functional::*;
@@ -267,4 +267,27 @@ fn test_concat() {
 
     assert_eq!(d, arr![i32; 1]);
     assert_eq!(e, arr![i32; 2, 3, 4]);
+}
+
+#[test]
+fn test_fold() {
+    let a = arr![i32; 1, 2, 3, 4];
+
+    assert_eq!(10, a.fold(0, |a, x| a + x));
+}
+
+fn sum_generic<S>(s: S) -> i32
+where
+    S: FunctionalSequence<i32>,
+    SequenceItem<S>: Add<i32, Output=i32>, // `+`
+    i32: Add<SequenceItem<S>, Output=i32>, // reflexive
+{
+    s.fold(0, |a, x| a + x)
+}
+
+#[test]
+fn test_sum() {
+    let a = sum_generic(arr![i32; 1, 2, 3, 4]);
+
+    assert_eq!(a, 10);
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -156,7 +156,8 @@ fn test_zip() {
     let a: GenericArray<_, U4> = GenericArray::generate(|i| i + 1);
     let b: GenericArray<_, U4> = GenericArray::generate(|i| i as i32 * 4);
 
-    let c = (&a).zip(&b, |r, l| *r as i32 + l);
+    // Uses reference and non-reference arguments
+    let c = (&a).zip(b, |r, l| *r as i32 + l);
 
     assert_eq!(c, arr![i32; 1, 6, 11, 16]);
 }

--- a/tests/std.rs
+++ b/tests/std.rs
@@ -1,6 +1,5 @@
 #![recursion_limit="128"]
 
-//#[macro_use]
 extern crate generic_array;
 
 use std::fmt::Debug;
@@ -11,11 +10,11 @@ use generic_array::sequence::*;
 use generic_array::functional::*;
 
 pub fn test_generic<S>(s: S)
-    where
-        S: FunctionalSequence<i32>,            // `.map`
-        SequenceItem<S>: Add<i32, Output=i32>, // `+`
-        S: MappedGenericSequence<i32, i32>,    // `i32` -> `i32`
-        MappedSequence<S, i32, i32>: Debug     // println!
+where
+    S: FunctionalSequence<i32>,            // `.map`
+    SequenceItem<S>: Add<i32, Output=i32>, // `+`
+    S: MappedGenericSequence<i32, i32>,    // `i32` -> `i32`
+    MappedSequence<S, i32, i32>: Debug     // println!
 {
     let a = s.map(|x| x + 1);
 

--- a/tests/std.rs
+++ b/tests/std.rs
@@ -12,7 +12,7 @@ use generic_array::functional::*;
 pub fn test_generic<S>(s: S)
 where
     S: FunctionalSequence<i32>,            // `.map`
-    SequenceItem<S>: Add<i32, Output=i32>, // `+`
+    S::Item: Add<i32, Output=i32>, // `+`
     S: MappedGenericSequence<i32, i32>,    // `i32` -> `i32`
     MappedSequence<S, i32, i32>: Debug     // println!
 {

--- a/tests/std.rs
+++ b/tests/std.rs
@@ -1,0 +1,23 @@
+#![recursion_limit="128"]
+
+//#[macro_use]
+extern crate generic_array;
+
+use std::fmt::Debug;
+use std::ops::Add;
+
+//use generic_array::GenericArray;
+use generic_array::sequence::*;
+use generic_array::functional::*;
+
+pub fn test_generic<S>(s: S)
+    where
+        S: FunctionalSequence<i32>,
+        SequenceItem<S>: Add<i32, Output=i32>,
+        S: MappedGenericSequence<i32, i32>,
+        MappedSequence<S, i32, i32>: Debug
+{
+    let a = s.map(|x| x + 1);
+
+    println!("{:?}", a);
+}

--- a/tests/std.rs
+++ b/tests/std.rs
@@ -12,10 +12,10 @@ use generic_array::functional::*;
 
 pub fn test_generic<S>(s: S)
     where
-        S: FunctionalSequence<i32>,
-        SequenceItem<S>: Add<i32, Output=i32>,
-        S: MappedGenericSequence<i32, i32>,
-        MappedSequence<S, i32, i32>: Debug
+        S: FunctionalSequence<i32>,            // `.map`
+        SequenceItem<S>: Add<i32, Output=i32>, // `+`
+        S: MappedGenericSequence<i32, i32>,    // `i32` -> `i32`
+        MappedSequence<S, i32, i32>: Debug     // println!
 {
     let a = s.map(|x| x + 1);
 


### PR DESCRIPTION
This explanation is going to be a bit wild.

Basically, my entire motivation for this and the previous work with `zip`, `map` and so forth was to organize safe operations in a way conducive to compiler optimizations, specifically auto-vectorization.

Unfortunately, this only seems to work on slices with a known size at compile-time. I guess because they are an intrinsic type. Any and all attempts to get a custom iterator to optimize like that has failed, even with unstable features.

Even though they technically worked, I wasn't happy with how the previous work did functional operations, with `map`/`map_ref` and `zip`/`zip_ref`. It felt a bit unintuitive. They were also strictly attached to the `GenericArray` type, so they were useless with `GenericSequence` by itself, like with generics.

So, I've redefined `GenericSequence` like this:
```rust
pub unsafe trait GenericSequence<T>: Sized + IntoIterator {
    type Length: ArrayLength<T>;
    type Sequence: GenericSequence<T, Length=Self::Length> + FromIterator<T>;

    fn generate<F>(f: F) -> Self::Sequence
        where F: Fn(usize) -> T;
}
```
where `Sequence` is defined as `Self` for the `GenericArray` implementation.

That may seem redundant, but now `GenericSequence` is broadly implemented for `&'a S` and `&'a mut S`, and carries over the same `Sequence`. 

So:
```rust
<&'a S as GenericSequence<T>>::Sequence == <S as GenericSequence<T>>::Sequence
```

Furthermore, `IntoIterator` is now implemented for `&'a GenericArray<T, N>` and `&'a mut GenericArray<T, N>`, where both of those implementations use slice iterators, and each reference type **automatically** implements `GenericSequence<T>`

Next, I've added a new trait called `MappedGenericSequence`, which looks like:

```rust
pub unsafe trait MappedGenericSequence<T, U>: GenericSequence<T>
where
    Self::Length: ArrayLength<U>,
{
    type Mapped: GenericSequence<U, Length=Self::Length>;
}
```

and the implementation of that for `GenericArray` is just:

```rust
unsafe impl<T, U, N> MappedGenericSequence<T, U> for GenericArray<T, N>
where
    N: ArrayLength<T> + ArrayLength<U>,
    GenericArray<U, N>: GenericSequence<U, Length=N>,
{
    type Mapped = GenericArray<U, N>;
}
```

As you can see, it just defines another arbitrary `GenericArray` with the same length. The transformation allows for proving one `GenericArray` can be created from another, which leads into the `FunctionalSequence` trait.

You can see the default implementation for it in `src/functional.rs`, which uses the fact that any `GenericSequence` is `IntoIterator` and the associated `Sequence` is `FromIterator` to map/zip sequences using only simple iterators.

`FunctionalSequence` is also automatically implemented for `&'a S` and `&'a mut S` where `S: GenericSequence<T>`, so they automatically work with `&GenericArray` as well.

Furthermore, it's implemented directly on `GenericArray` as well, which uses the `ArrayConsumer` system to provide a lightweight and optimizable implementation, rather than relying on `GenericArrayIter`, which cannot be optimized.

As a result, code like in the assembly test:

```rust
let a = black_box(arr![i32; 1, 3, 5, 7]);
let b = black_box(arr![i32; 2, 4, 6, 8]);

let c = a.zip(&b, |l: i32, r: &i32| l + r);

assert_eq!(c, arr![i32; 3, 7, 11, 15]);
```

will correctly be optimized into a single VPADDD instruction, just as desired.

~~The **downside** of this is that non-reference RHS arguments will kill this optimization, because it will use `.into_iter()` and `GenericArrayIter`. There really isn't a good way around this currently.~~ I found a good way around this currently.

The **upside** of all of this is that pass any random `GenericSequence` without knowing the length is finally feasible, as shown in `tests/std.rs`, and here:

```rust
pub fn test_generic<S>(s: S)
    where
        S: FunctionalSequence<i32>,            // `.map`
        SequenceItem<S>: Add<i32, Output=i32>, // `+`
        S: MappedGenericSequence<i32, i32>,    // `i32` -> `i32`
        MappedSequence<S, i32, i32>: Debug     // println!
{
    let a = s.map(|x| x + 1);

    println!("{:?}", a);
}
```

Which still has zero runtime length checking, but we've avoided having to know the length of the sequence. Furthermore, now `test_generic` can work for `GenericArray`, `&GenericArray` and `&mut GenericArray` with no problems.

**BREAKING CHANGES**:
* The implementation of `FromIterator` for `GenericArray` now panics when the given iterator doesn't produce enough elements, wherein before it padded it with defaults.
* `map_ref` and `zip_ref` are gone, replaced with the new functional system.
* ~~`map`/`zip` can fail to optimize unless used with references.~~ Fixed
    * I should note that auto-vectorization only works on numbers anyway, so it's no worse than `vec::IntoIter` in the worst case.
* `GenericArray` and `GenericArrayIter` now implement `Send`/`Sync` when possible.

What do you think? Perhaps I should write up some examples for the docs, too?

If I failed to explain anything, made a mistake or could improve on anything, please let me know. I just want to make the best things I can.