### PR TITLE
Fix length of formatted hex string when truncation is enabled

### DIFF
--- a/src/hex.rs
+++ b/src/hex.rs
@@ -19,6 +19,7 @@ use {ArrayLength, GenericArray};
 use core::fmt;
 use core::ops::Add;
 use core::str;
+use core::cmp::min;
 use typenum::*;
 
 static LOWER_CHARS: &'static [u8] = b"0123456789abcdef";
@@ -30,28 +31,32 @@ where
     <T as Add<T>>::Output: ArrayLength<u8>,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let max_digits = f.precision().unwrap_or_else(|| self.len());
+        let max_digits = f.precision().unwrap_or_else(|| self.len()*2);
+        let max_hex = (max_digits >> 1) + (max_digits & 1);
 
         if T::to_usize() < 1024 {
             // For small arrays use a stack allocated
             // buffer of 2x number of bytes
             let mut res = GenericArray::<u8, Sum<T, T>>::default();
 
-            for (i, c) in self.iter().take(max_digits).enumerate() {
+            for (i, c) in self.iter().take(max_hex).enumerate() {
                 res[i * 2] = LOWER_CHARS[(c >> 4) as usize];
                 res[i * 2 + 1] = LOWER_CHARS[(c & 0xF) as usize];
             }
-            f.write_str(unsafe { str::from_utf8_unchecked(&res[..max_digits * 2]) })?;
+            f.write_str(unsafe { str::from_utf8_unchecked(&res[..max_digits]) })?;
         } else {
             // For large array use chunks of up to 1024 bytes (2048 hex chars)
             let mut buf = [0u8; 2048];
+            let mut digits_left = max_digits;
 
-            for chunk in self[..max_digits].chunks(1024) {
+            for chunk in self[..max_hex].chunks(1024) {
                 for (i, c) in chunk.iter().enumerate() {
                     buf[i * 2] = LOWER_CHARS[(c >> 4) as usize];
                     buf[i * 2 + 1] = LOWER_CHARS[(c & 0xF) as usize];
                 }
-                f.write_str(unsafe { str::from_utf8_unchecked(&buf[..chunk.len() * 2]) })?;
+                let n = min(chunk.len() * 2, digits_left);
+                f.write_str(unsafe { str::from_utf8_unchecked(&buf[..n]) })?;
+                digits_left -= n;
             }
         }
         Ok(())
@@ -64,28 +69,32 @@ where
     <T as Add<T>>::Output: ArrayLength<u8>,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let max_digits = f.precision().unwrap_or_else(|| self.len());
+        let max_digits = f.precision().unwrap_or_else(|| self.len()*2);
+        let max_hex = (max_digits >> 1) + (max_digits & 1);
 
         if T::to_usize() < 1024 {
             // For small arrays use a stack allocated
             // buffer of 2x number of bytes
             let mut res = GenericArray::<u8, Sum<T, T>>::default();
 
-            for (i, c) in self.iter().take(max_digits).enumerate() {
+            for (i, c) in self.iter().take(max_hex).enumerate() {
                 res[i * 2] = UPPER_CHARS[(c >> 4) as usize];
                 res[i * 2 + 1] = UPPER_CHARS[(c & 0xF) as usize];
             }
-            f.write_str(unsafe { str::from_utf8_unchecked(&res[..max_digits * 2]) })?;
+            f.write_str(unsafe { str::from_utf8_unchecked(&res[..max_digits]) })?;
         } else {
             // For large array use chunks of up to 1024 bytes (2048 hex chars)
             let mut buf = [0u8; 2048];
+            let mut digits_left = max_digits;
 
-            for chunk in self[..max_digits].chunks(1024) {
+            for chunk in self[..max_hex].chunks(1024) {
                 for (i, c) in chunk.iter().enumerate() {
                     buf[i * 2] = UPPER_CHARS[(c >> 4) as usize];
                     buf[i * 2 + 1] = UPPER_CHARS[(c & 0xF) as usize];
                 }
-                f.write_str(unsafe { str::from_utf8_unchecked(&buf[..chunk.len() * 2]) })?;
+                let n = min(chunk.len() * 2, digits_left);
+                f.write_str(unsafe { str::from_utf8_unchecked(&buf[..n]) })?;
+                digits_left -= n;
             }
         }
         Ok(())

--- a/tests/hex.rs
+++ b/tests/hex.rs
@@ -26,19 +26,37 @@ fn long_lower_hex() {
 }
 
 #[test]
+fn long_lower_hex_truncated() {
+    let ar = GenericArray::<u8, U2048>::default();
+    assert_eq!(format!("{:.3001x}", ar), from_utf8(&[b'0'; 3001]).unwrap());
+}
+
+#[test]
 fn long_upper_hex() {
     let ar = GenericArray::<u8, U2048>::default();
     assert_eq!(format!("{:X}", ar), from_utf8(&[b'0'; 4096]).unwrap());
 }
 
 #[test]
+fn long_upper_hex_truncated() {
+    let ar = GenericArray::<u8, U2048>::default();
+    assert_eq!(format!("{:.2777X}", ar), from_utf8(&[b'0'; 2777]).unwrap());
+}
+
+#[test]
 fn truncated_lower_hex() {
     let ar = arr![u8; 10, 20, 30, 40, 50];
-    assert_eq!(format!("{:.2x}", ar), "0a14");
+    assert_eq!(format!("{:.2x}", ar), "0a");
+    assert_eq!(format!("{:.3x}", ar), "0a1");
+    assert_eq!(format!("{:.4x}", ar), "0a14");
 }
 
 #[test]
 fn truncated_upper_hex() {
     let ar = arr![u8; 30, 20, 10, 17, 0];
-    assert_eq!(format!("{:.4X}", ar), "1E140A11");
+    assert_eq!(format!("{:.4X}", ar), "1E14");
+    assert_eq!(format!("{:.5X}", ar), "1E140");
+    assert_eq!(format!("{:.6X}", ar), "1E140A");
+    assert_eq!(format!("{:.7X}", ar), "1E140A1");
+    assert_eq!(format!("{:.8X}", ar), "1E140A11");
 }


### PR DESCRIPTION
Sorry, this was a large oversight on my part. And it was even covered by tests, but..

Previously `{:.2x}` format string would encode two bytes yielding `1a2b`, instead of producing two bytes output `1a`. After this PR it produces exactly two characters.

While technically this is a breaking change, I think it worth it because it makes it consistent with other formatting use cases (i.e. `{:.2}` for strings)