### PR TITLE
Make Array Consumer/Builder structures public, but hidden, for use in other crates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,20 +161,23 @@ where
     }
 }
 
-struct ArrayBuilder<T, N: ArrayLength<T>> {
-    array: ManuallyDrop<GenericArray<T, N>>,
-    position: usize,
+#[doc(hidden)]
+pub struct ArrayBuilder<T, N: ArrayLength<T>> {
+    pub array: ManuallyDrop<GenericArray<T, N>>,
+    pub position: usize,
 }
 
 impl<T, N: ArrayLength<T>> ArrayBuilder<T, N> {
-    fn new() -> ArrayBuilder<T, N> {
+    #[doc(hidden)]
+    pub fn new() -> ArrayBuilder<T, N> {
         ArrayBuilder {
             array: ManuallyDrop::new(unsafe { mem::uninitialized() }),
             position: 0,
         }
     }
 
-    fn into_inner(self) -> GenericArray<T, N> {
+    #[doc(hidden)]
+    pub fn into_inner(self) -> GenericArray<T, N> {
         let array = unsafe { ptr::read(&self.array) };
 
         mem::forget(self);
@@ -193,13 +196,15 @@ impl<T, N: ArrayLength<T>> Drop for ArrayBuilder<T, N> {
     }
 }
 
-struct ArrayConsumer<T, N: ArrayLength<T>> {
-    array: ManuallyDrop<GenericArray<T, N>>,
-    position: usize,
+#[doc(hidden)]
+pub struct ArrayConsumer<T, N: ArrayLength<T>> {
+    pub array: ManuallyDrop<GenericArray<T, N>>,
+    pub position: usize,
 }
 
 impl<T, N: ArrayLength<T>> ArrayConsumer<T, N> {
-    fn new(array: GenericArray<T, N>) -> ArrayConsumer<T, N> {
+    #[doc(hidden)]
+    pub fn new(array: GenericArray<T, N>) -> ArrayConsumer<T, N> {
         ArrayConsumer {
             array: ManuallyDrop::new(array),
             position: 0,

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -36,7 +36,7 @@ pub unsafe trait GenericSequence<T>: Sized + IntoIterator {
         Self::Length: ArrayLength<B> + ArrayLength<U>,
         F: FnMut(B, Self::Item) -> U,
     {
-        let mut left = ArrayConsumer::new(lhs);
+        let mut left = unsafe { ArrayConsumer::new(lhs) };
 
         let ArrayConsumer {
             array: ref left_array,

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -36,25 +36,23 @@ pub unsafe trait GenericSequence<T>: Sized + IntoIterator {
         Self::Length: ArrayLength<B> + ArrayLength<U>,
         F: FnMut(B, Self::Item) -> U,
     {
-        let mut left = unsafe { ArrayConsumer::new(lhs) };
+        unsafe {
+            let mut left = ArrayConsumer::new(lhs);
 
-        let ArrayConsumer {
-            array: ref left_array,
-            position: ref mut left_position,
-        } = left;
+            let (left_array_iter, left_position) = left.iter_position();
 
-        FromIterator::from_iter(
-            left_array
-                .iter()
-                .zip(self.into_iter())
-                .map(|(l, right_value)| {
-                    let left_value = unsafe { ptr::read(l) };
+            FromIterator::from_iter(
+                left_array_iter
+                    .zip(self.into_iter())
+                    .map(|(l, right_value)| {
+                        let left_value = ptr::read(l);
 
-                    *left_position += 1;
+                        *left_position += 1;
 
-                    f(left_value, right_value)
-                }),
-        )
+                        f(left_value, right_value)
+                    })
+            )
+        }
     }
 
     #[doc(hidden)]


### PR DESCRIPTION
I thought it was silly that I had to re-implement `ArrayBuilder` and `ArrayConsumer` for `numeric-array`, so I think we should just expose those quietly.

I went ahead and implemented a simple "API" for the private stuff and added some doc comments for anyone that wants to snoop around the source code to use them. I also converted our existing code to use the API, because why not.

This isn't a breaking change, though, so a quick minor revision is good enough. Everything still works the exact same and should produce nearly identical machine code.