### PR TITLE
Allow arr! to be imported with use syntax

### DIFF
--- a/src/arr.rs
+++ b/src/arr.rs
@@ -29,16 +29,16 @@ macro_rules! arr_impl {
         unsafe { $crate::transmute::<_, $crate::GenericArray<$T, $N>>([$($x),*]) }
     });
     ($T:ty; $N:ty, [], [$x1:expr]) => (
-        arr_impl!($T; $crate::arr::Inc<$T, $N>, [$x1 as $T], [])
+        $crate::arr_impl!($T; $crate::arr::Inc<$T, $N>, [$x1 as $T], [])
     );
     ($T:ty; $N:ty, [], [$x1:expr, $($x:expr),+]) => (
-        arr_impl!($T; $crate::arr::Inc<$T, $N>, [$x1 as $T], [$($x),+])
+        $crate::arr_impl!($T; $crate::arr::Inc<$T, $N>, [$x1 as $T], [$($x),+])
     );
     ($T:ty; $N:ty, [$($y:expr),+], [$x1:expr]) => (
-        arr_impl!($T; $crate::arr::Inc<$T, $N>, [$($y),+, $x1 as $T], [])
+        $crate::arr_impl!($T; $crate::arr::Inc<$T, $N>, [$($y),+, $x1 as $T], [])
     );
     ($T:ty; $N:ty, [$($y:expr),+], [$x1:expr, $($x:expr),+]) => (
-        arr_impl!($T; $crate::arr::Inc<$T, $N>, [$($y),+, $x1 as $T], [$($x),+])
+        $crate::arr_impl!($T; $crate::arr::Inc<$T, $N>, [$($y),+, $x1 as $T], [$($x),+])
     );
 }
 
@@ -50,7 +50,7 @@ macro_rules! arr {
         unsafe { $crate::transmute::<[$T; 0], $crate::GenericArray<$T, $crate::typenum::U0>>([]) }
     });
     ($T:ty; $($x:expr),* $(,)*) => (
-        arr_impl!($T; $crate::typenum::U0, [], [$($x),*])
+        $crate::arr_impl!($T; $crate::typenum::U0, [], [$($x),*])
     );
     ($($x:expr,)+) => (arr![$($x),*]);
     () => ("""Macro requires a type, e.g. `let array = arr![u32; 1, 2, 3];`")


### PR DESCRIPTION
Currently, using the `arr!` macro when it has been imported via `use generic_array::arr;` causes a compilation error. Prefixing invocations of the `arr_impl!` macro with `$crate::` fixes this. This change will increase generic-array's minimum required rustc version to 1.30, if that's something you're concerned about.