### PR TITLE
Use and improve internal iteration support

### DIFF
--- a/src/hex.rs
+++ b/src/hex.rs
@@ -15,12 +15,12 @@
 //! ```
 //!
 
-use {ArrayLength, GenericArray};
 use core::cmp::min;
 use core::fmt;
 use core::ops::Add;
 use core::str;
 use typenum::*;
+use {ArrayLength, GenericArray};
 
 static LOWER_CHARS: &'static [u8] = b"0123456789abcdef";
 static UPPER_CHARS: &'static [u8] = b"0123456789ABCDEF";
@@ -39,10 +39,11 @@ where
             // buffer of 2x number of bytes
             let mut res = GenericArray::<u8, Sum<T, T>>::default();
 
-            for (i, c) in self.iter().take(max_hex).enumerate() {
+            self.iter().take(max_hex).enumerate().for_each(|(i, c)| {
                 res[i * 2] = LOWER_CHARS[(c >> 4) as usize];
                 res[i * 2 + 1] = LOWER_CHARS[(c & 0xF) as usize];
-            }
+            });
+
             f.write_str(unsafe { str::from_utf8_unchecked(&res[..max_digits]) })?;
         } else {
             // For large array use chunks of up to 1024 bytes (2048 hex chars)
@@ -50,10 +51,11 @@ where
             let mut digits_left = max_digits;
 
             for chunk in self[..max_hex].chunks(1024) {
-                for (i, c) in chunk.iter().enumerate() {
+                chunk.iter().enumerate().for_each(|(i, c)| {
                     buf[i * 2] = LOWER_CHARS[(c >> 4) as usize];
                     buf[i * 2 + 1] = LOWER_CHARS[(c & 0xF) as usize];
-                }
+                });
+
                 let n = min(chunk.len() * 2, digits_left);
                 f.write_str(unsafe { str::from_utf8_unchecked(&buf[..n]) })?;
                 digits_left -= n;
@@ -77,10 +79,11 @@ where
             // buffer of 2x number of bytes
             let mut res = GenericArray::<u8, Sum<T, T>>::default();
 
-            for (i, c) in self.iter().take(max_hex).enumerate() {
+            self.iter().take(max_hex).enumerate().for_each(|(i, c)| {
                 res[i * 2] = UPPER_CHARS[(c >> 4) as usize];
                 res[i * 2 + 1] = UPPER_CHARS[(c & 0xF) as usize];
-            }
+            });
+
             f.write_str(unsafe { str::from_utf8_unchecked(&res[..max_digits]) })?;
         } else {
             // For large array use chunks of up to 1024 bytes (2048 hex chars)
@@ -88,10 +91,11 @@ where
             let mut digits_left = max_digits;
 
             for chunk in self[..max_hex].chunks(1024) {
-                for (i, c) in chunk.iter().enumerate() {
+                chunk.iter().enumerate().for_each(|(i, c)| {
                     buf[i * 2] = UPPER_CHARS[(c >> 4) as usize];
                     buf[i * 2 + 1] = UPPER_CHARS[(c & 0xF) as usize];
-                }
+                });
+
                 let n = min(chunk.len() * 2, digits_left);
                 f.write_str(unsafe { str::from_utf8_unchecked(&buf[..n]) })?;
                 digits_left -= n;

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -21,7 +21,7 @@ where
     N: ArrayLength<T>,
 {
     fn clone(&self) -> GenericArray<T, N> {
-        self.map(|x| x.clone())
+        self.map(Clone::clone)
     }
 }
 
@@ -40,11 +40,7 @@ where
         **self == **other
     }
 }
-impl<T: Eq, N> Eq for GenericArray<T, N>
-where
-    N: ArrayLength<T>,
-{
-}
+impl<T: Eq, N> Eq for GenericArray<T, N> where N: ArrayLength<T> {}
 
 impl<T: PartialOrd, N> PartialOrd for GenericArray<T, N>
 where

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,8 +1,8 @@
 //! `GenericArray` iterator implementation.
 
 use super::{ArrayLength, GenericArray};
-use core::{cmp, ptr, fmt, mem};
 use core::mem::ManuallyDrop;
+use core::{cmp, fmt, mem, ptr};
 
 /// An iterator that moves out of a `GenericArray`
 pub struct GenericArrayIter<T, N: ArrayLength<T>> {
@@ -129,6 +129,34 @@ where
         } else {
             None
         }
+    }
+
+    fn fold<B, F>(mut self, init: B, mut f: F) -> B
+    where
+        F: FnMut(B, Self::Item) -> B,
+    {
+        let ret = unsafe {
+            let GenericArrayIter {
+                ref array,
+                ref mut index,
+                index_back,
+            } = self;
+
+            let remaining = &array[*index..index_back];
+
+            remaining.iter().fold(init, |acc, src| {
+                let value = ptr::read(src);
+
+                *index += 1;
+
+                f(acc, value)
+            })
+        };
+
+        // ensure the drop happens here after iteration
+        drop(self);
+
+        ret
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,8 +98,8 @@ impl<T: Clone, U: Clone> Clone for GenericArrayImplEven<T, U> {
             parent1: self.parent1.clone(),
             parent2: self.parent2.clone(),
             _marker: PhantomData,
-        }
     }
+}
 }
 
 impl<T: Copy, U: Copy> Copy for GenericArrayImplEven<T, U> {}
@@ -120,8 +120,8 @@ impl<T: Clone, U: Clone> Clone for GenericArrayImplOdd<T, U> {
             parent1: self.parent1.clone(),
             parent2: self.parent2.clone(),
             data: self.data.clone(),
-        }
     }
+}
 }
 
 impl<T: Copy, U: Copy> Copy for GenericArrayImplOdd<T, U> {}
@@ -298,11 +298,13 @@ where
             {
                 let (destination_iter, position) = destination.iter_position();
 
-                for (src, dst) in iter.into_iter().zip(destination_iter) {
-                    ptr::write(dst, src);
+                iter.into_iter()
+                    .zip(destination_iter)
+                    .for_each(|(src, dst)| {
+                        ptr::write(dst, src);
 
-                    *position += 1;
-                }
+                        *position += 1;
+                    });
             }
 
             if destination.position < N::to_usize() {
@@ -341,11 +343,11 @@ where
             {
                 let (destination_iter, position) = destination.iter_position();
 
-                for (i, dst) in destination_iter.enumerate() {
+                destination_iter.enumerate().for_each(|(i, dst)| {
                     ptr::write(dst, f(i));
 
                     *position += 1;
-                }
+                });
             }
 
             destination.into_inner()
@@ -570,11 +572,11 @@ where
                 {
                     let (destination_iter, position) = destination.iter_position();
 
-                    for (dst, src) in destination_iter.zip(iter.into_iter()) {
+                    destination_iter.zip(iter).for_each(|(dst, src)| {
                         ptr::write(dst, src);
 
                         *position += 1;
-                    }
+                    });
                 }
 
                 Some(destination.into_inner())

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -1,8 +1,8 @@
 //! Useful traits for manipulating sequences of data stored in `GenericArray`s
 
 use super::*;
-use core::{mem, ptr};
 use core::ops::{Add, Sub};
+use core::{mem, ptr};
 use typenum::operator_aliases::*;
 
 /// Defines some sequence with an associated length and iteration capabilities.
@@ -41,17 +41,15 @@ pub unsafe trait GenericSequence<T>: Sized + IntoIterator {
 
             let (left_array_iter, left_position) = left.iter_position();
 
-            FromIterator::from_iter(
-                left_array_iter
-                    .zip(self.into_iter())
-                    .map(|(l, right_value)| {
+            FromIterator::from_iter(left_array_iter.zip(self.into_iter()).map(
+                |(l, right_value)| {
                         let left_value = ptr::read(l);
 
                         *left_position += 1;
 
                         f(left_value, right_value)
-                    })
-            )
+                },
+            ))
         }
     }
 

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -94,14 +94,19 @@ fn test_into_iter_flat_map() {
 
 #[test]
 fn test_into_iter_fold() {
-    assert_eq!(arr![i32; 1, 2, 3, 4].into_iter().fold(0, |sum, x| sum + x), 10);
+    assert_eq!(
+        arr![i32; 1, 2, 3, 4].into_iter().fold(0, |sum, x| sum + x),
+        10
+    );
 
     let mut iter = arr![i32; 0, 1, 2, 3, 4, 5].into_iter();
 
     iter.next();
     iter.next_back();
 
-    assert_eq!(iter.fold(0, |sum, x| sum + x), 10);
+    assert_eq!(iter.clone().fold(0, |sum, x| sum + x), 10);
+
+    assert_eq!(iter.rfold(0, |sum, x| sum + x), 10);
 }
 
 #[test]

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -4,8 +4,8 @@ extern crate generic_array;
 use std::cell::Cell;
 use std::ops::Drop;
 
-use generic_array::GenericArray;
 use generic_array::typenum::consts::U5;
+use generic_array::GenericArray;
 
 #[test]
 fn test_into_iter_as_slice() {
@@ -93,21 +93,31 @@ fn test_into_iter_flat_map() {
 }
 
 #[test]
+fn test_into_iter_fold() {
+    assert_eq!(arr![i32; 1, 2, 3, 4].into_iter().fold(0, |sum, x| sum + x), 10);
+
+    let mut iter = arr![i32; 0, 1, 2, 3, 4, 5].into_iter();
+
+    iter.next();
+    iter.next_back();
+
+    assert_eq!(iter.fold(0, |sum, x| sum + x), 10);
+}
+
+#[test]
 fn test_into_iter_drops() {
     struct R<'a> {
-       i: &'a Cell<usize>,
+        i: &'a Cell<usize>,
     }
 
     impl<'a> Drop for R<'a> {
-       fn drop(&mut self) {
+        fn drop(&mut self) {
             self.i.set(self.i.get() + 1);
         }
     }
 
     fn r(i: &Cell<usize>) -> R {
-        R {
-            i: i
-        }
+        R { i: i }
     }
 
     fn v(i: &Cell<usize>) -> GenericArray<R, U5> {

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -4,10 +4,10 @@
 extern crate generic_array;
 use core::cell::Cell;
 use core::ops::{Add, Drop};
-use generic_array::GenericArray;
 use generic_array::functional::*;
 use generic_array::sequence::*;
 use generic_array::typenum::{U1, U3, U4, U97};
+use generic_array::GenericArray;
 
 #[test]
 fn test() {
@@ -124,8 +124,8 @@ fn test_cmp() {
 mod impl_serde {
     extern crate serde_json;
 
-    use generic_array::GenericArray;
     use generic_array::typenum::U6;
+    use generic_array::GenericArray;
 
     #[test]
     fn test_serde_implementation() {
@@ -178,7 +178,15 @@ fn test_from_iter() {
 #[test]
 fn test_sizes() {
     #![allow(dead_code)]
+    use core::ffi::c_void;
     use core::mem::{size_of, size_of_val};
+
+    #[derive(Debug, Copy, Clone)]
+    enum E {
+        V,
+        V2(i32),
+        V3 { h: bool, i: i32 },
+    }
 
     #[derive(Debug, Copy, Clone)]
     #[repr(C)]
@@ -186,12 +194,21 @@ fn test_sizes() {
     struct Test {
         t: u16,
         s: u32,
+        mm: bool,
         r: u16,
         f: u16,
+        p: (),
         o: u32,
+        ff: *const extern "C" fn(*const char) -> *const c_void,
+        l: *const c_void,
+        w: bool,
+        q: bool,
+        v: E,
     }
 
-    assert_eq!(size_of::<Test>(), 14);
+    assert_eq!(size_of::<E>(), 8);
+
+    assert_eq!(size_of::<Test>(), 25 + size_of::<usize>() * 2);
 
     assert_eq!(size_of_val(&arr![u8; 1, 2, 3]), size_of::<u8>() * 3);
     assert_eq!(size_of_val(&arr![u32; 1]), size_of::<u32>() * 1);


### PR DESCRIPTION
In the [latest "This Week in Rust"](https://this-week-in-rust.org/blog/2019/04/09/this-week-in-rust-281/), one update to Rust core [was to use `for_each` where possible on a few things](https://github.com/rust-lang/rust/pull/59740) to allow complex iterators to use specialized behavior in the form of `fold` to improve performance.

So, in this PR (aside from a few changes due to rustfmt updates) it is now using internal iteration via `for_each` wherever possible, and I've implemented a specialized `fold` on `GenericArrayIter` to allow faster traversal of it inside `for_each`.