### PR TITLE
Clean up arr macro implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ more_lengths = []
 [dependencies]
 typenum = "1.10"
 serde = { version = "1.0", optional = true, default-features = false }
+arrayvec = { version = "0.5", optional = true }
 
 [dev_dependencies]
 # this can't yet be made optional, see https://github.com/rust-lang/cargo/issues/1596

--- a/src/arr.rs
+++ b/src/arr.rs
@@ -1,57 +1,17 @@
 //! Implementation for `arr!` macro.
 
-use super::ArrayLength;
-use core::ops::Add;
-use typenum::U1;
-
-/// Helper trait for `arr!` macro
-pub trait AddLength<T, N: ArrayLength<T>>: ArrayLength<T> {
-    /// Resulting length
-    type Output: ArrayLength<T>;
-}
-
-impl<T, N1, N2> AddLength<T, N2> for N1
-where
-    N1: ArrayLength<T> + Add<N2>,
-    N2: ArrayLength<T>,
-    <N1 as Add<N2>>::Output: ArrayLength<T>,
-{
-    type Output = <N1 as Add<N2>>::Output;
-}
-
-/// Helper type for `arr!` macro
-pub type Inc<T, U> = <U as AddLength<T, U1>>::Output;
-
-#[doc(hidden)]
-#[macro_export]
-macro_rules! arr_impl {
-    ($T:ty; $N:ty, [$($x:expr),*], []) => ({
-        unsafe { $crate::transmute::<_, $crate::GenericArray<$T, $N>>([$($x),*]) }
-    });
-    ($T:ty; $N:ty, [], [$x1:expr]) => (
-        $crate::arr_impl!($T; $crate::arr::Inc<$T, $N>, [$x1 as $T], [])
-    );
-    ($T:ty; $N:ty, [], [$x1:expr, $($x:expr),+]) => (
-        $crate::arr_impl!($T; $crate::arr::Inc<$T, $N>, [$x1 as $T], [$($x),+])
-    );
-    ($T:ty; $N:ty, [$($y:expr),+], [$x1:expr]) => (
-        $crate::arr_impl!($T; $crate::arr::Inc<$T, $N>, [$($y),+, $x1 as $T], [])
-    );
-    ($T:ty; $N:ty, [$($y:expr),+], [$x1:expr, $($x:expr),+]) => (
-        $crate::arr_impl!($T; $crate::arr::Inc<$T, $N>, [$($y),+, $x1 as $T], [$($x),+])
-    );
-}
-
 /// Macro allowing for easy generation of Generic Arrays.
 /// Example: `let test = arr![u32; 1, 2, 3];`
 #[macro_export]
 macro_rules! arr {
-    ($T:ty; $(,)*) => ({
-        unsafe { $crate::transmute::<[$T; 0], $crate::GenericArray<$T, $crate::typenum::U0>>([]) }
-    });
-    ($T:ty; $($x:expr),* $(,)*) => (
-        $crate::arr_impl!($T; $crate::typenum::U0, [], [$($x),*])
-    );
-    ($($x:expr,)+) => (arr![$($x),*]);
-    () => ("""Macro requires a type, e.g. `let array = arr![u32; 1, 2, 3];`")
+    ($T:ty; $($rest:tt)*) => {{
+        let out: $crate::GenericArray<$T, _> = $crate::arr![$($rest)*];
+        out
+    }};
+    ($first:expr $(, $rest:expr)* $(,)*) => {
+        $crate::sequence::Lengthen::prepend($crate::arr![$($rest),*], $first)
+    };
+    ($(,)*) => {
+        $crate::GenericArray::new()
+    };
 }

--- a/src/impl_serde.rs
+++ b/src/impl_serde.rs
@@ -91,7 +91,7 @@ mod tests {
         array[0] = 1;
         array[1] = 2;
         let serialized = bincode::serialize(&array).unwrap();
-        let deserialized = bincode::deserialize::<GenericArray<u8, typenum::U2>>(&array);
+        let deserialized = bincode::deserialize::<GenericArray<u8, typenum::U2>>(&serialized);
         assert!(deserialized.is_ok());
         let array = deserialized.unwrap();
         assert_eq!(array[0], 1);

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -144,6 +144,7 @@ macro_rules! impl_from {
 }
 
 impl_from! {
+    0  => ::typenum::U0,
     1  => ::typenum::U1,
     2  => ::typenum::U2,
     3  => ::typenum::U3,

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -139,6 +139,14 @@ macro_rules! impl_from {
                     unsafe { $crate::transmute(self) }
                 }
             }
+
+            impl<T> $crate::IntoArray for GenericArray<T, $ty> {
+                type Array = [T; $n];
+
+                fn into_array(self) -> Self::Array {
+                    self.into()
+                }
+            }
         )*
     }
 }

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -239,3 +239,22 @@ impl_from! {
     1000 => ::typenum::U1000,
     1024 => ::typenum::U1024
 }
+
+#[cfg(feature = "arrayvec")]
+unsafe impl<T, Size> arrayvec::Array for GenericArray<T, Size>
+where
+    Size: ArrayLength<T> + typenum::Unsigned,
+{
+    type Item = T;
+    // TODO: Have a trait that can tell the smallest int type that can hold a `typenum::Unsigned`
+    type Index = usize;
+    const CAPACITY: usize = Size::USIZE;
+
+    fn as_slice(&self) -> &[Self::Item] {
+        self.as_slice()
+    }
+
+    fn as_mut_slice(&mut self) -> &mut [Self::Item] {
+        self.as_mut_slice()
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -607,6 +607,18 @@ pub unsafe fn transmute<A, B>(a: A) -> B {
     b
 }
 
+/// Concrete conversion to a fixed-size array. Since there is only one fixed-size array
+/// type that each generic array type can convert to, this allows us to easier work with
+/// these in a generic way.
+pub trait IntoArray {
+    /// The concrete Rust-level fixed-size array type.
+    type Array;
+
+    /// Convert into the fixed-size array type. If you already know the input and output
+    /// types this is equivalent to `Into::into` but it can be useful in a generic context.
+    fn into_array(self) -> Self::Array;
+}
+
 #[cfg(test)]
 mod test {
     // Compile with:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -483,6 +483,13 @@ where
     }
 }
 
+impl<T> GenericArray<T, typenum::consts::U0> {
+    /// Creates a new, empty array
+    pub fn new() -> Self {
+        GenericArray { data: () }
+    }
+}
+
 impl<T, N> GenericArray<T, N>
 where
     N: ArrayLength<T>,

--- a/tests/arr.rs
+++ b/tests/arr.rs
@@ -25,3 +25,27 @@ fn with_trailing_comma() {
     let ar = arr![u8; 10, 20, 30, ];
     assert_eq!(format!("{:x}", ar), "0a141e");
 }
+
+#[test]
+fn empty_without_trailing_comma_no_type() {
+    let ar = arr![];
+    assert_eq!(format!("{:x}", ar), "");
+}
+
+#[test]
+fn empty_with_trailing_comma_no_type() {
+    let ar = arr![, ];
+    assert_eq!(format!("{:x}", ar), "");
+}
+
+#[test]
+fn without_trailing_comma_no_type() {
+    let ar = arr![10, 20, 30];
+    assert_eq!(format!("{:x}", ar), "0a141e");
+}
+
+#[test]
+fn with_trailing_comma_no_type() {
+    let ar = arr![10, 20, 30,];
+    assert_eq!(format!("{:x}", ar), "0a141e");
+}


### PR DESCRIPTION
This PR removes some unsafe code and generally cleans up the implementation of `arr`, allowing for arrays with inferred element types. To help with this, a `new` method has been added to create empty `GenericArray`s, as well as a `From<[T; 0]>` impl for the same. Right now it's unnecessarily difficult to create empty `GenericArray`s, as evidenced by the fact that the previous implementation of the `arr` macro used unsafe code to do so.

I also fixed what appeared to be a typo in another test, it appears to be intended to be a serialisation round-trip test but it did not actually round-trip the serialisation.