### PR TITLE
Replace `Into` implementations with `From`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 * **`0.14.0`**
     * Replace `Into` implementations with the more general `From`.
-        * Requires minumum Rust version of 1.40.0
+        * Requires minumum Rust version of 1.41.0
 
 * **`0.13.2`**
     * Add feature `more_lengths`, which adds more `From`/`Into` implementations for arrays of various lengths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* **`0.14.0`**
+    * Replace `Into` implementations with the more general `From`.
+        * Requires minumum Rust version of 1.40.0
+
 * **`0.13.2`**
     * Add feature `more_lengths`, which adds more `From`/`Into` implementations for arrays of various lengths.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "generic-array"
-version = "0.13.2"
+version = "0.14.0"
 authors = [ "Bartłomiej Kamiński <fizyk20@gmail.com>", "Aaron Trent <novacrazy@gmail.com>" ]
 
 description = "Generic types implementing functionality of arrays"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This crate implements generic array types for Rust.
 
-**Requires minumum Rust version of 1.30.1**
+**Requires minumum Rust version of 1.41.0**
 
 [Documentation](http://fizyk20.github.io/generic-array/generic_array/)
 

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -133,10 +133,10 @@ macro_rules! impl_from {
                 }
             }
 
-            impl<T> Into<[T; $n]> for GenericArray<T, $ty> {
+            impl<T> From<GenericArray<T, $ty>> for [T; $n] {
                 #[inline(always)]
-                fn into(self) -> [T; $n] {
-                    unsafe { $crate::transmute(self) }
+                fn from(sel: GenericArray<T, $ty>) -> [T; $n] {
+                    unsafe { $crate::transmute(sel) }
                 }
             }
         )*


### PR DESCRIPTION
The rust [1.41.0](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1410-2020-01-30) release relaxes trait coherence rules. It's now possible to	`impl From<LocalType> for ForeignType`.

As mentioned in [std docs](https://doc.rust-lang.org/stable/std/convert/trait.Into.html), `From` should be implemented if possible, while `Into` can be used as a fallback.

There some odd cases when `Into` alone is not sufficient, I bumped into one of those cases today, hence the pr. :)