### PR TITLE
Add Split impl for &GenericArray and &mut GenericArray

### DIFF
--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -279,6 +279,46 @@ where
     }
 }
 
+unsafe impl<'a, T, N, K> Split<T, K> for &'a GenericArray<T, N>
+where
+    N: ArrayLength<T>,
+    K: ArrayLength<T> + 'static,
+    N: Sub<K>,
+    Diff<N, K>: ArrayLength<T>,
+{
+    type First = &'a GenericArray<T, K>;
+    type Second = &'a GenericArray<T, Diff<N, K>>;
+
+    fn split(self) -> (Self::First, Self::Second) {
+        unsafe {
+            let ptr_to_first: *const T = self.as_ptr();
+            let head = &*(ptr_to_first as *const _);
+            let tail = &*(ptr_to_first.add(K::USIZE) as *const _);
+            (head, tail)
+        }
+    }
+}
+
+unsafe impl<'a, T, N, K> Split<T, K> for &'a mut GenericArray<T, N>
+where
+    N: ArrayLength<T>,
+    K: ArrayLength<T> + 'static,
+    N: Sub<K>,
+    Diff<N, K>: ArrayLength<T>,
+{
+    type First = &'a mut GenericArray<T, K>;
+    type Second = &'a mut GenericArray<T, Diff<N, K>>;
+
+    fn split(self) -> (Self::First, Self::Second) {
+        unsafe {
+            let ptr_to_first: *mut T = self.as_mut_ptr();
+            let head = &mut *(ptr_to_first as *mut _);
+            let tail = &mut *(ptr_to_first.add(K::USIZE) as *mut _);
+            (head, tail)
+        }
+    }
+}
+
 /// Defines `GenericSequence`s which can be joined together, forming a larger array.
 pub unsafe trait Concat<T, M>: GenericSequence<T>
 where

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -266,6 +266,38 @@ fn test_split() {
 }
 
 #[test]
+fn test_split_ref() {
+    let a = arr![i32; 1, 2, 3, 4];
+    let a_ref = &a;
+
+    let (b_ref, c_ref) = a_ref.split();
+
+    assert_eq!(b_ref, &arr![i32; 1]);
+    assert_eq!(c_ref, &arr![i32; 2, 3, 4]);
+
+    let (e_ref, f_ref) = a_ref.split();
+
+    assert_eq!(e_ref, &arr![i32; 1, 2]);
+    assert_eq!(f_ref, &arr![i32; 3, 4]);
+}
+
+#[test]
+fn test_split_mut() {
+    let mut a = arr![i32; 1, 2, 3, 4];
+    let a_ref = &mut a;
+
+    let (b_ref, c_ref) = a_ref.split();
+
+    assert_eq!(b_ref, &mut arr![i32; 1]);
+    assert_eq!(c_ref, &mut arr![i32; 2, 3, 4]);
+
+    let (e_ref, f_ref) = a_ref.split();
+
+    assert_eq!(e_ref, &mut arr![i32; 1, 2]);
+    assert_eq!(f_ref, &mut arr![i32; 3, 4]);
+}
+
+#[test]
 fn test_concat() {
     let a = arr![i32; 1, 2];
     let b = arr![i32; 3, 4];


### PR DESCRIPTION
This adds `Split` implementations for
- `&GenericArray<T, N>`
- `&mut GenericArray<T, N>`
to allow splitting of references to obtain references back.