### PR TITLE
Add AsRef<[T; N]> and AsMut<[T; N]> impls to GenericArray<T, N>

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -139,6 +139,20 @@ macro_rules! impl_from {
                     unsafe { $crate::transmute(self) }
                 }
             }
+
+            impl<T> AsRef<[T; $n]> for GenericArray<T, $ty> {
+                #[inline]
+                fn as_ref(&self) -> &[T; $n] {
+                    unsafe { $crate::transmute(self) }
+                }
+            }
+
+            impl<T> AsMut<[T; $n]> for GenericArray<T, $ty> {
+                #[inline]
+                fn as_mut(&mut self) -> &mut [T; $n] {
+                    unsafe { $crate::transmute(self) }
+                }
+            }
         )*
     }
 }

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -302,3 +302,20 @@ fn test_sum() {
 
     assert_eq!(a, 10);
 }
+
+#[test]
+fn test_as_ref() {
+    let a = arr![i32; 1, 2, 3, 4];
+    let a_ref: &[i32; 4] = a.as_ref();
+    assert_eq!(a_ref, &[1, 2, 3, 4]);
+}
+
+#[test]
+fn test_as_mut() {
+    let mut a = arr![i32; 1, 2, 3, 4];
+    let a_mut: &mut [i32; 4] = a.as_mut();
+    assert_eq!(a_mut, &mut [1, 2, 3, 4]);
+    a_mut[2] = 0;
+    assert_eq!(a_mut, &mut [1, 2, 0, 4]);
+    assert_eq!(a, arr![i32; 1, 2, 0, 4]);
+}


### PR DESCRIPTION
Adds the following trait implementations to `GenericArray<T, N>` for many concrete `N`:
- `AsRef<[T; N]>`
- `AsMut<[T; N]>`

This is very useful in combination with https://github.com/fizyk20/generic-array/pull/92 (split) as you initially construct a single big static array, split it up and modify it with different methods. Everything is still a no-op and statically checked by the compiler.