### PR TITLE
Impl 'From' only on 1.41+. Else, fallback to 'Into'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,6 @@ serde = { version = "1.0", optional = true, default-features = false }
 # this can't yet be made optional, see https://github.com/rust-lang/cargo/issues/1596
 serde_json = "1.0"
 bincode = "1.0"
+
+[build_dependencies]
+version_check = "0.9"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if version_check::is_min_version("1.41.0").unwrap_or(false) {
+        println!("cargo:rustc-cfg=relaxed_coherence");
+    }
+}

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -133,10 +133,19 @@ macro_rules! impl_from {
                 }
             }
 
+            #[cfg(relaxed_coherence)]
             impl<T> From<GenericArray<T, $ty>> for [T; $n] {
                 #[inline(always)]
                 fn from(sel: GenericArray<T, $ty>) -> [T; $n] {
                     unsafe { $crate::transmute(sel) }
+                }
+            }
+
+            #[cfg(not(relaxed_coherence))]
+            impl<T> Into<[T; $n]> for GenericArray<T, $ty> {
+                #[inline(always)]
+                fn into(self) -> [T; $n] {
+                    unsafe { $crate::transmute(self) }
                 }
             }
 


### PR DESCRIPTION
This reduces the MSRV to 1.36.0, reverting breakage on older compilers. This is a backwards compatible change: if the crate built, the compiler version was 1.41+, and it used the new `From`, as this PR continues to do. If it didn't, now it will!