### PR TITLE
Add From<&[T;N]> and From<&mut [T; N]> impls for &[mut] GenericArray

### DIFF
--- a/src/impls.rs
+++ b/src/impls.rs
@@ -140,6 +140,20 @@ macro_rules! impl_from {
                 }
             }
 
+            impl<'a, T> From<&'a [T; $n]> for &'a GenericArray<T, $ty> {
+                #[inline]
+                fn from(slice: &[T; $n]) -> &GenericArray<T, $ty> {
+                    unsafe { &*(slice.as_ptr() as *const GenericArray<T, $ty>) }
+                }
+            }
+
+            impl<'a, T> From<&'a mut [T; $n]> for &'a mut GenericArray<T, $ty> {
+                #[inline]
+                fn from(slice: &mut [T; $n]) -> &mut GenericArray<T, $ty> {
+                    unsafe { &mut *(slice.as_mut_ptr() as *mut GenericArray<T, $ty>) }
+                }
+            }
+
             impl<T> AsRef<[T; $n]> for GenericArray<T, $ty> {
                 #[inline]
                 fn as_ref(&self) -> &[T; $n] {

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -351,3 +351,20 @@ fn test_as_mut() {
     assert_eq!(a_mut, &mut [1, 2, 0, 4]);
     assert_eq!(a, arr![i32; 1, 2, 0, 4]);
 }
+
+#[test]
+fn test_from_array_ref() {
+    let mut a = arr![i32; 1, 2, 3, 4];
+    let a_ref: &[i32; 4] = a.as_ref();
+    let a_from: &GenericArray<i32, U4> = a_ref.into();
+    assert_eq!(&a, a_from);
+}
+
+#[test]
+fn test_from_array_mut() {
+    let mut a = arr![i32; 1, 2, 3, 4];
+    let mut a_copy = a;
+    let a_mut: &mut [i32; 4] = a.as_mut();
+    let a_from: &mut GenericArray<i32, U4> = a_mut.into();
+    assert_eq!(&mut a_copy, a_from);
+}


### PR DESCRIPTION
Adds the following impls to `GenericArray`:

- `impl From<&'a [T; N]> for &'a GenericArray<T, N>`
- `impl From<&'a mut [T; N]> for &'a mut GenericArray<T, N>`

So far users had to convert their `&'a [mut] [T; N]` array references into slices to perform the conversion into the `GenericArray` reference. This also resulted into an additional unnecessary assertion since the length are known anyways.

This PR adds the missing `From` implementations to drop the unnecessary assertion in those cases and to allow direct conversions between array references and generic array references.