### PR TITLE
Fix unsoundness in `from_exact_iter`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -596,7 +596,7 @@ where
         I: IntoIterator<Item = T>,
         <I as IntoIterator>::IntoIter: ExactSizeIterator,
     {
-        let iter = iter.into_iter();
+        let mut iter = iter.into_iter();
 
         if iter.len() == N::USIZE {
             unsafe {
@@ -605,11 +605,13 @@ where
                 {
                     let (destination_iter, position) = destination.iter_position();
 
-                    destination_iter.zip(iter).for_each(|(dst, src)| {
+                    destination_iter.zip(&mut iter).for_each(|(dst, src)| {
                         ptr::write(dst, src);
 
                         *position += 1;
                     });
+                    assert_eq!(*position, N::USIZE, "ExactSizeIterator lied about its length");
+                    assert!(iter.next().is_none(), "ExactSizeIterator lied about its length");
                 }
 
                 Some(destination.into_inner())

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -8,7 +8,6 @@ use generic_array::typenum::consts::U5;
 use generic_array::GenericArray;
 
 #[test]
-#[should_panic(expected = "ExactSizeIterator lied about its length")]
 fn test_from_iterator() {
     struct BadExact(usize);
 
@@ -25,7 +24,7 @@ fn test_from_iterator() {
     impl ExactSizeIterator for BadExact {
         fn len(&self) -> usize { self.0 }
     }
-    let _array = GenericArray::<usize, U5>::from_exact_iter(BadExact(5)).unwrap();
+    assert!(GenericArray::<usize, U5>::from_exact_iter(BadExact(5)).is_none());
 }
 
 #[test]

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -8,6 +8,27 @@ use generic_array::typenum::consts::U5;
 use generic_array::GenericArray;
 
 #[test]
+#[should_panic(expected = "ExactSizeIterator lied about its length")]
+fn test_from_iterator() {
+    struct BadExact(usize);
+
+    impl Iterator for BadExact {
+        type Item = usize;
+        fn next(&mut self) -> Option<usize> {
+            if self.0 == 1 {
+                return None;
+            }
+            self.0 -= 1;
+            Some(self.0)
+        }
+    }
+    impl ExactSizeIterator for BadExact {
+        fn len(&self) -> usize { self.0 }
+    }
+    let _array = GenericArray::<usize, U5>::from_exact_iter(BadExact(5)).unwrap();
+}
+
+#[test]
 fn test_into_iter_as_slice() {
     let array = arr![char; 'a', 'b', 'c'];
     let mut into_iter = array.into_iter();


### PR DESCRIPTION
While trying to figure out how to remove the `Default` bound from the `Deserialize` impl I found some unsoundness in `from_exact_iter`. Unfortunately `ExactSizeIterator` is not an `unsafe` trait, so you can't rely on it returning correct results for soundness.

Alternatively, what do you think about removing the `ExactSizeIterator` bound and just returning `None` when either of these assertions would trigger? That is not a breaking change and would allow various other use cases like creating `GenericArray`s from `std::iter::from_fn` iterators combined with `take` and similar.