### PR TITLE
Add optional support for Zeroize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ more_lengths = []
 [dependencies]
 typenum = "1.12"
 serde = { version = "1.0", optional = true, default-features = false }
+zeroize = { version = "1.1", optional = true, default-features = false }
 
 [dev_dependencies]
 # this can't yet be made optional, see https://github.com/rust-lang/cargo/issues/1596

--- a/src/impl_zeroize.rs
+++ b/src/impl_zeroize.rs
@@ -1,0 +1,27 @@
+use {ArrayLength, GenericArray};
+use zeroize::{Zeroize};
+
+impl<T, N> Zeroize for GenericArray<T, N>
+where
+    T: Zeroize,
+    N: ArrayLength<T>,
+{
+    fn zeroize(&mut self) {
+        self.iter_mut().zeroize();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_zeroize() {
+        let mut array = GenericArray::<u8, typenum::U2>::default();
+        array[0] = 4;
+        array[1] = 9;
+        array.zeroize();
+        assert_eq!(array[0], 0);
+        assert_eq!(array[1], 0);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,9 @@
 #[cfg(feature = "serde")]
 extern crate serde;
 
+#[cfg(feature = "zeroize")]
+extern crate zeroize;
+
 #[cfg(test)]
 extern crate bincode;
 
@@ -82,6 +85,9 @@ mod impls;
 
 #[cfg(feature = "serde")]
 mod impl_serde;
+
+#[cfg(feature = "zeroize")]
+mod impl_zeroize;
 
 use core::iter::FromIterator;
 use core::marker::PhantomData;


### PR DESCRIPTION
zeroize is the most popular crate for zeroizing memory after use.
generic-array is the most popular crate for representing bytes in
cryptographic implementations which can't use an allocator.

Issues have been opened in RustCrypto about zeroizing instances of
generic-array, for instance here:
https://github.com/RustCrypto/hashes/issues/87

However, sometimes you want to return generic-array from an API
while also commiting it to be zeroized after use, because the caller
might forget to do this on some code path. The natural way to do that
in zeroize crate is the `Zeroizing` wrapper. However, `Zeroizing`
cannot be used with `generic-array` unless `generic-array` implements
the `Zeroize` trait.

The easiest way to do that is create an optional dependency on
`Zeroize` and put the implementation in a conditionally-compiled
module, as we did in this commit.