### PR TITLE
Update to Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 name = "generic-array"
 version = "0.14.4"
 authors = [ "Bartłomiej Kamiński <fizyk20@gmail.com>", "Aaron Trent <novacrazy@gmail.com>" ]
+edition = "2018"
 
 description = "Generic types implementing functionality of arrays"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ repository = "https://github.com/fizyk20/generic-array.git"
 
 keywords = ["generic", "array"]
 categories = ["data-structures", "no-std"]
+include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md", "build.rs"]
 
 [badges]
 travis-ci = { repository = "fizyk20/generic-array" }

--- a/src/functional.rs
+++ b/src/functional.rs
@@ -82,14 +82,12 @@ pub unsafe trait FunctionalSequence<T>: GenericSequence<T> {
     }
 }
 
-unsafe impl<'a, T, S: GenericSequence<T>> FunctionalSequence<T> for &'a S
-where
-    &'a S: GenericSequence<T>,
+unsafe impl<'a, T, S: GenericSequence<T>> FunctionalSequence<T> for &'a S where
+    &'a S: GenericSequence<T>
 {
 }
 
-unsafe impl<'a, T, S: GenericSequence<T>> FunctionalSequence<T> for &'a mut S
-where
-    &'a mut S: GenericSequence<T>,
+unsafe impl<'a, T, S: GenericSequence<T>> FunctionalSequence<T> for &'a mut S where
+    &'a mut S: GenericSequence<T>
 {
 }

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -5,13 +5,13 @@
 //! Example:
 //!
 //! ```rust
-//! # #[macro_use]
-//! # extern crate generic_array;
-//! # extern crate typenum;
-//! # fn main() {
-//! let array = arr![u8; 10, 20, 30];
-//! assert_eq!(format!("{:x}", array), "0a141e");
-//! # }
+//! use generic_array::arr;
+//! use generic_array::typenum;
+//!
+//! fn main() {
+//!     let array = arr![u8; 10, 20, 30];
+//!     assert_eq!(format!("{:x}", array), "0a141e");
+//! }
 //! ```
 //!
 

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -15,14 +15,14 @@
 //! ```
 //!
 
-use core::{fmt, str, ops::Add, cmp::min};
+use core::{cmp::min, fmt, ops::Add, str};
 
 use typenum::*;
 
 use crate::{ArrayLength, GenericArray};
 
-static LOWER_CHARS: &'static [u8] = b"0123456789abcdef";
-static UPPER_CHARS: &'static [u8] = b"0123456789ABCDEF";
+static LOWER_CHARS: &[u8] = b"0123456789abcdef";
+static UPPER_CHARS: &[u8] = b"0123456789ABCDEF";
 
 impl<T: ArrayLength<u8>> fmt::LowerHex for GenericArray<u8, T>
 where

--- a/src/impl_serde.rs
+++ b/src/impl_serde.rs
@@ -1,10 +1,10 @@
 //! Serde serialization/deserialization implementation
 
+use crate::{ArrayLength, GenericArray};
 use core::fmt;
 use core::marker::PhantomData;
 use serde::de::{self, SeqAccess, Visitor};
 use serde::{ser::SerializeTuple, Deserialize, Deserializer, Serialize, Serializer};
-use {ArrayLength, GenericArray};
 
 impl<T, N> Serialize for GenericArray<T, N>
 where
@@ -75,8 +75,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bincode;
-    use typenum;
 
     #[test]
     fn test_serialize() {
@@ -104,5 +102,4 @@ mod tests {
         let size = bincode::serialized_size(&array).unwrap();
         assert_eq!(size, 1);
     }
-
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -2,8 +2,8 @@
 
 use super::{ArrayLength, GenericArray};
 use core::iter::FusedIterator;
-use core::mem::{MaybeUninit, ManuallyDrop};
-use core::{cmp, fmt, ptr, mem};
+use core::mem::{ManuallyDrop, MaybeUninit};
+use core::{cmp, fmt, mem, ptr};
 
 /// An iterator that moves out of a `GenericArray`
 pub struct GenericArrayIter<T, N: ArrayLength<T>> {
@@ -110,7 +110,7 @@ where
             GenericArrayIter {
                 array: ManuallyDrop::new(array.assume_init()),
                 index: 0,
-                index_back
+                index_back,
             }
         }
     }
@@ -248,10 +248,6 @@ where
     }
 }
 
-impl<T, N> FusedIterator for GenericArrayIter<T, N>
-where
-    N: ArrayLength<T>,
-{
-}
+impl<T, N> FusedIterator for GenericArrayIter<T, N> where N: ArrayLength<T> {}
 
 // TODO: Implement `TrustedLen` when stabilized

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,9 +56,8 @@
 //! For ease of use, an `arr!` macro is provided - example below:
 //!
 //! ```
-//! # #[macro_use]
-//! # extern crate generic_array;
-//! # extern crate typenum;
+//! use generic_array::arr;
+//! use generic_array::typenum;
 //! # fn main() {
 //! let array = arr![u32; 1, 2, 3];
 //! assert_eq!(array[2], 3);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,12 +69,6 @@
 #![deny(meta_variable_misuse)]
 #![no_std]
 
-#[cfg(feature = "serde")]
-extern crate serde;
-
-#[cfg(test)]
-extern crate bincode;
-
 pub extern crate typenum;
 
 mod hex;
@@ -85,7 +79,7 @@ mod impl_serde;
 
 use core::iter::FromIterator;
 use core::marker::PhantomData;
-use core::mem::{MaybeUninit, ManuallyDrop};
+use core::mem::{ManuallyDrop, MaybeUninit};
 use core::ops::{Deref, DerefMut};
 use core::{mem, ptr, slice};
 use typenum::bit::{B0, B1};
@@ -226,7 +220,10 @@ impl<T, N: ArrayLength<T>> ArrayBuilder<T, N> {
     #[doc(hidden)]
     #[inline]
     pub unsafe fn iter_position(&mut self) -> (slice::IterMut<T>, &mut usize) {
-        ((&mut *self.array.as_mut_ptr()).iter_mut(), &mut self.position)
+        (
+            (&mut *self.array.as_mut_ptr()).iter_mut(),
+            &mut self.position,
+        )
     }
 
     /// When done writing (assuming all elements have been written to),

--- a/src/sequence.rs
+++ b/src/sequence.rs
@@ -1,8 +1,8 @@
 //! Useful traits for manipulating sequences of data stored in `GenericArray`s
 
 use super::*;
-use core::ops::{Add, Sub};
 use core::mem::MaybeUninit;
+use core::ops::{Add, Sub};
 use core::ptr;
 use typenum::operator_aliases::*;
 
@@ -31,8 +31,8 @@ pub unsafe trait GenericSequence<T>: Sized + IntoIterator {
         mut f: F,
     ) -> MappedSequence<GenericArray<B, Self::Length>, B, U>
     where
-        GenericArray<B, Self::Length>: GenericSequence<B, Length = Self::Length>
-            + MappedGenericSequence<B, U>,
+        GenericArray<B, Self::Length>:
+            GenericSequence<B, Length = Self::Length> + MappedGenericSequence<B, U>,
         Self: MappedGenericSequence<T, U>,
         Self::Length: ArrayLength<B> + ArrayLength<U>,
         F: FnMut(B, Self::Item) -> U,
@@ -44,11 +44,11 @@ pub unsafe trait GenericSequence<T>: Sized + IntoIterator {
 
             FromIterator::from_iter(left_array_iter.zip(self.into_iter()).map(
                 |(l, right_value)| {
-                        let left_value = ptr::read(l);
+                    let left_value = ptr::read(l);
 
-                        *left_position += 1;
+                    *left_position += 1;
 
-                        f(left_value, right_value)
+                    f(left_value, right_value)
                 },
             ))
         }

--- a/tests/arr.rs
+++ b/tests/arr.rs
@@ -1,6 +1,4 @@
-#[macro_use]
-extern crate generic_array;
-extern crate typenum;
+use generic_array::arr;
 
 #[test]
 fn empty_without_trailing_comma() {

--- a/tests/generics.rs
+++ b/tests/generics.rs
@@ -1,24 +1,22 @@
 #![recursion_limit = "128"]
-
-#[macro_use]
-extern crate generic_array;
+use generic_array::arr;
 
 use generic_array::typenum::consts::U4;
 
 use std::fmt::Debug;
 use std::ops::Add;
 
-use generic_array::{GenericArray, ArrayLength};
-use generic_array::sequence::*;
 use generic_array::functional::*;
+use generic_array::sequence::*;
+use generic_array::{ArrayLength, GenericArray};
 
 /// Example function using generics to pass N-length sequences and map them
 pub fn generic_map<S>(s: S)
 where
-    S: FunctionalSequence<i32>,            // `.map`
-    S::Item: Add<i32, Output = i32>,       // `x + 1`
-    S: MappedGenericSequence<i32, i32>,    // `i32` -> `i32`
-    MappedSequence<S, i32, i32>: Debug,    // println!
+    S: FunctionalSequence<i32>,         // `.map`
+    S::Item: Add<i32, Output = i32>,    // `x + 1`
+    S: MappedGenericSequence<i32, i32>, // `i32` -> `i32`
+    MappedSequence<S, i32, i32>: Debug, // println!
 {
     let a = s.map(|x| x + 1);
 
@@ -30,16 +28,16 @@ where
 /// If used with `GenericArray` specifically this isn't necessary
 pub fn generic_sequence_zip_sum<A, B>(a: A, b: B) -> i32
 where
-    A: FunctionalSequence<i32>,                                                                 // `.zip`
-    B: FunctionalSequence<i32, Length = A::Length>,                                             // `.zip`
-    A: MappedGenericSequence<i32, i32>,                                                         // `i32` -> `i32`
-    B: MappedGenericSequence<i32, i32, Mapped = MappedSequence<A, i32, i32>>,                   // `i32` -> `i32`, prove A and B can map to the same output
-    A::Item: Add<B::Item, Output = i32>,                                                        // `l + r`
-    MappedSequence<A, i32, i32>: MappedGenericSequence<i32, i32> + FunctionalSequence<i32>,     // `.map`
-    SequenceItem<MappedSequence<A, i32, i32>>: Add<i32, Output=i32>,                            // `x + 1`
-    MappedSequence<MappedSequence<A, i32, i32>, i32, i32>: Debug,                               // `println!`
-    MappedSequence<MappedSequence<A, i32, i32>, i32, i32>: FunctionalSequence<i32>,             // `.fold`
-    SequenceItem<MappedSequence<MappedSequence<A, i32, i32>, i32, i32>>: Add<i32, Output=i32>   // `x + a`, note the order
+    A: FunctionalSequence<i32>,                     // `.zip`
+    B: FunctionalSequence<i32, Length = A::Length>, // `.zip`
+    A: MappedGenericSequence<i32, i32>,             // `i32` -> `i32`
+    B: MappedGenericSequence<i32, i32, Mapped = MappedSequence<A, i32, i32>>, // `i32` -> `i32`, prove A and B can map to the same output
+    A::Item: Add<B::Item, Output = i32>,                                      // `l + r`
+    MappedSequence<A, i32, i32>: MappedGenericSequence<i32, i32> + FunctionalSequence<i32>, // `.map`
+    SequenceItem<MappedSequence<A, i32, i32>>: Add<i32, Output = i32>, // `x + 1`
+    MappedSequence<MappedSequence<A, i32, i32>, i32, i32>: Debug,      // `println!`
+    MappedSequence<MappedSequence<A, i32, i32>, i32, i32>: FunctionalSequence<i32>, // `.fold`
+    SequenceItem<MappedSequence<MappedSequence<A, i32, i32>, i32, i32>>: Add<i32, Output = i32>, // `x + a`, note the order
 {
     let c = a.zip(b, |l, r| l + r).map(|x| x + 1);
 
@@ -53,17 +51,23 @@ pub fn generic_array_plain_zip_sum(a: GenericArray<i32, U4>, b: GenericArray<i32
     a.zip(b, |l, r| l + r).map(|x| x + 1).fold(0, |a, x| x + a)
 }
 
-pub fn generic_array_variable_length_zip_sum<N>(a: GenericArray<i32, N>, b: GenericArray<i32, N>) -> i32
+pub fn generic_array_variable_length_zip_sum<N>(
+    a: GenericArray<i32, N>,
+    b: GenericArray<i32, N>,
+) -> i32
 where
     N: ArrayLength<i32>,
 {
     a.zip(b, |l, r| l + r).map(|x| x + 1).fold(0, |a, x| x + a)
 }
 
-pub fn generic_array_same_type_variable_length_zip_sum<T, N>(a: GenericArray<T, N>, b: GenericArray<T, N>) -> i32
+pub fn generic_array_same_type_variable_length_zip_sum<T, N>(
+    a: GenericArray<T, N>,
+    b: GenericArray<T, N>,
+) -> i32
 where
     N: ArrayLength<T> + ArrayLength<<T as Add<T>>::Output>,
-    T: Add<T, Output=i32>,
+    T: Add<T, Output = i32>,
 {
     a.zip(b, |l, r| l + r).map(|x| x + 1).fold(0, |a, x| x + a)
 }
@@ -71,13 +75,16 @@ where
 /// Complex example using fully generic `GenericArray`s with the same length.
 ///
 /// It's mostly just the repeated `Add` traits, which would be present in other systems anyway.
-pub fn generic_array_zip_sum<A, B, N: ArrayLength<A> + ArrayLength<B>>(a: GenericArray<A, N>, b: GenericArray<B, N>) -> i32
+pub fn generic_array_zip_sum<A, B, N: ArrayLength<A> + ArrayLength<B>>(
+    a: GenericArray<A, N>,
+    b: GenericArray<B, N>,
+) -> i32
 where
     A: Add<B>,
-    N: ArrayLength<<A as Add<B>>::Output> +
-        ArrayLength<<<A as Add<B>>::Output as Add<i32>>::Output>,
+    N: ArrayLength<<A as Add<B>>::Output>
+        + ArrayLength<<<A as Add<B>>::Output as Add<i32>>::Output>,
     <A as Add<B>>::Output: Add<i32>,
-    <<A as Add<B>>::Output as Add<i32>>::Output: Add<i32, Output=i32>,
+    <<A as Add<B>>::Output as Add<i32>>::Output: Add<i32, Output = i32>,
 {
     a.zip(b, |l, r| l + r).map(|x| x + 1).fold(0, |a, x| x + a)
 }
@@ -86,13 +93,31 @@ where
 fn test_generics() {
     generic_map(arr![i32; 1, 2, 3, 4]);
 
-    assert_eq!(generic_sequence_zip_sum(arr![i32; 1, 2, 3, 4], arr![i32; 2, 3, 4, 5]), 28);
+    assert_eq!(
+        generic_sequence_zip_sum(arr![i32; 1, 2, 3, 4], arr![i32; 2, 3, 4, 5]),
+        28
+    );
 
-    assert_eq!(generic_array_plain_zip_sum(arr![i32; 1, 2, 3, 4], arr![i32; 2, 3, 4, 5]), 28);
+    assert_eq!(
+        generic_array_plain_zip_sum(arr![i32; 1, 2, 3, 4], arr![i32; 2, 3, 4, 5]),
+        28
+    );
 
-    assert_eq!(generic_array_variable_length_zip_sum(arr![i32; 1, 2, 3, 4], arr![i32; 2, 3, 4, 5]), 28);
+    assert_eq!(
+        generic_array_variable_length_zip_sum(arr![i32; 1, 2, 3, 4], arr![i32; 2, 3, 4, 5]),
+        28
+    );
 
-    assert_eq!(generic_array_same_type_variable_length_zip_sum(arr![i32; 1, 2, 3, 4], arr![i32; 2, 3, 4, 5]), 28);
+    assert_eq!(
+        generic_array_same_type_variable_length_zip_sum(
+            arr![i32; 1, 2, 3, 4],
+            arr![i32; 2, 3, 4, 5]
+        ),
+        28
+    );
 
-    assert_eq!(generic_array_zip_sum(arr![i32; 1, 2, 3, 4], arr![i32; 2, 3, 4, 5]), 28);
+    assert_eq!(
+        generic_array_zip_sum(arr![i32; 1, 2, 3, 4], arr![i32; 2, 3, 4, 5]),
+        28
+    );
 }

--- a/tests/hex.rs
+++ b/tests/hex.rs
@@ -1,7 +1,5 @@
-#[macro_use]
-extern crate generic_array;
-extern crate typenum;
-
+use generic_array::arr;
+use generic_array::typenum;
 use generic_array::GenericArray;
 use std::str::from_utf8;
 use typenum::U2048;

--- a/tests/import_name.rs
+++ b/tests/import_name.rs
@@ -1,6 +1,6 @@
-#[macro_use]
-extern crate generic_array as gen_arr;
+use generic_array as gen_arr;
 
+use gen_arr::arr;
 use gen_arr::typenum;
 
 #[test]

--- a/tests/iter.rs
+++ b/tests/iter.rs
@@ -1,5 +1,4 @@
-#[macro_use]
-extern crate generic_array;
+use generic_array::arr;
 
 use std::cell::Cell;
 use std::ops::Drop;
@@ -22,7 +21,9 @@ fn test_from_iterator() {
         }
     }
     impl ExactSizeIterator for BadExact {
-        fn len(&self) -> usize { self.0 }
+        fn len(&self) -> usize {
+            self.0
+        }
     }
     assert!(GenericArray::<usize, U5>::from_exact_iter(BadExact(5)).is_none());
 }
@@ -80,9 +81,9 @@ fn test_into_iter_clone() {
 fn test_into_iter_nth() {
     let v = arr![i32; 0, 1, 2, 3, 4];
     for i in 0..v.len() {
-        assert_eq!(v.clone().into_iter().nth(i).unwrap(), v[i]);
+        assert_eq!(v.into_iter().nth(i).unwrap(), v[i]);
     }
-    assert_eq!(v.clone().into_iter().nth(v.len()), None);
+    assert_eq!(v.into_iter().nth(v.len()), None);
 
     let mut iter = v.into_iter();
     assert_eq!(iter.nth(2).unwrap(), v[2]);
@@ -99,7 +100,7 @@ fn test_into_iter_last() {
 #[test]
 fn test_into_iter_count() {
     let v = arr![i32; 0, 1, 2, 3, 4];
-    assert_eq!(v.clone().into_iter().count(), 5);
+    assert_eq!(v.into_iter().count(), 5);
 
     let mut iter2 = v.into_iter();
     iter2.next();
@@ -142,7 +143,7 @@ fn test_into_iter_drops() {
     }
 
     fn r(i: &Cell<usize>) -> R {
-        R { i: i }
+        R { i }
     }
 
     fn v(i: &Cell<usize>) -> GenericArray<R, U5> {

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,9 +1,8 @@
 #![recursion_limit = "128"]
 #![no_std]
-#[macro_use]
-extern crate generic_array;
 use core::cell::Cell;
 use core::ops::{Add, Drop};
+use generic_array::arr;
 use generic_array::functional::*;
 use generic_array::sequence::*;
 use generic_array::typenum::{U0, U3, U4, U97};
@@ -12,8 +11,8 @@ use generic_array::GenericArray;
 #[test]
 fn test() {
     let mut list97 = [0; 97];
-    for i in 0..97 {
-        list97[i] = i as i32;
+    for (i, elem) in list97.iter_mut().enumerate() {
+        *elem = i as i32;
     }
     let l: GenericArray<i32, U97> = GenericArray::clone_from_slice(&list97);
     assert_eq!(l[0], 0);
@@ -124,6 +123,7 @@ fn test_cmp() {
 mod impl_serde {
     extern crate serde_json;
 
+    use generic_array::arr;
     use generic_array::typenum::U6;
     use generic_array::GenericArray;
 
@@ -221,9 +221,18 @@ fn test_sizes() {
 fn test_alignment() {
     use core::mem::align_of;
 
-    assert_eq!(align_of::<GenericArray::<u32, U0>>(), align_of::<[u32; 0]>());
-    assert_eq!(align_of::<GenericArray::<u32, U3>>(), align_of::<[u32; 3]>());
-    assert_eq!(align_of::<GenericArray::<Test, U3>>(), align_of::<[Test; 3]>());
+    assert_eq!(
+        align_of::<GenericArray::<u32, U0>>(),
+        align_of::<[u32; 0]>()
+    );
+    assert_eq!(
+        align_of::<GenericArray::<u32, U3>>(),
+        align_of::<[u32; 3]>()
+    );
+    assert_eq!(
+        align_of::<GenericArray::<Test, U3>>(),
+        align_of::<[Test; 3]>()
+    );
 }
 
 #[test]


### PR DESCRIPTION
* Add `edition = "2018"` in `Cargo.toml` and remove the now old and unnecessary syntax like `extern crate`.
* Saved 42% or 45.0 KB in 10 files (of 107.4 KB and 23 files in entire crate) using the `include` field in the `Cargo.toml`, for a lighter crate.
* Format the code with `cargo fmt --all`