### PR TITLE
Shrink unsafe block

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -97,12 +97,12 @@ where
     fn clone(&self) -> Self {
         // This places all cloned elements at the start of the new array iterator,
         // not at their original indices.
-        unsafe {
-            let mut array = ptr::read(&self.array);
+        
+            let mut array = unsafe {ptr::read(&self.array)};
             let mut index_back = 0;
 
             for (dst, src) in array.as_mut_slice().into_iter().zip(self.as_slice()) {
-                ptr::write(dst, src.clone());
+                unsafe {ptr::write(dst, src.clone())};
                 index_back += 1;
             }
 
@@ -111,7 +111,7 @@ where
                 index: 0,
                 index_back
             }
-        }
+        
     }
 }
 


### PR DESCRIPTION
In this function you use the unsafe keyword for almost the entrie function body.

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust.

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html