### PR TITLE
Add an optional `Zeroize` impl for `GenericArray`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ more_lengths = []
 [dependencies]
 typenum = "1.12"
 serde = { version = "1.0", optional = true, default-features = false }
+zeroize = { version = "1", optional = true, default-features = false }
 
 [dev_dependencies]
 # this can't yet be made optional, see https://github.com/rust-lang/cargo/issues/1596

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,9 @@
 #[cfg(feature = "serde")]
 extern crate serde;
 
+#[cfg(feature = "zeroize")]
+extern crate zeroize;
+
 #[cfg(test)]
 extern crate bincode;
 
@@ -571,6 +574,14 @@ impl<'a, T, N: ArrayLength<T>> From<&'a mut [T]> for &'a mut GenericArray<T, N> 
         assert_eq!(slice.len(), N::USIZE);
 
         unsafe { &mut *(slice.as_mut_ptr() as *mut GenericArray<T, N>) }
+    }
+}
+
+#[cfg(feature = "zeroize")]
+#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
+impl<T: zeroize::Zeroize, N: ArrayLength<T>> zeroize::Zeroize for GenericArray<T, N> {
+    fn zeroize(&mut self) {
+        self.as_mut_slice().iter_mut().zeroize()
     }
 }
 


### PR DESCRIPTION
`GenericArray`s are used extensively in RustCrypto stack, and it would be very convenient to have them implement zeroization (for the cases when they contain secret data), so that one didn't have to make and expose a newtype doing that. This is done with the help of the de-facto standard [`zeroize`](https://docs.rs/zeroize/latest/zeroize/) crate. 

This functionality is optional and gated on the `zeroize` feature.

