### PR TITLE
repeat-expressions for arr macro

### DIFF
--- a/src/arr.rs
+++ b/src/arr.rs
@@ -41,6 +41,16 @@ macro_rules! arr_impl {
 
         __do_transmute::<$T, __OutputLength>([$($x as $T),*])
     });
+    ($T:ty; $x:expr; $N: ty) => ({
+        const __INPUT_LENGTH: usize = <$N as $crate::typenum::Unsigned>::USIZE;
+
+        #[inline(always)]
+        const fn __do_transmute<T, N: $crate::ArrayLength<T>>(arr: [T; __INPUT_LENGTH]) -> $crate::GenericArray<T, N> {
+            unsafe { $crate::transmute(arr) }
+        }
+
+        __do_transmute::<$T, $N>([$x; __INPUT_LENGTH])
+    });
 }
 
 /// Macro allowing for easy generation of Generic Arrays.
@@ -52,6 +62,9 @@ macro_rules! arr {
     });
     ($T:ty; $($x:expr),* $(,)*) => (
         $crate::arr_impl!($T; $($x),*)
+    );
+    ($T:ty; $x:expr; $N:ty) => (
+        $crate::arr_impl!($T; $x; $N)
     );
     ($($x:expr,)+) => (arr![$($x),+]);
     () => ("""Macro requires a type, e.g. `let array = arr![u32; 1, 2, 3];`")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -639,9 +639,15 @@ where
 /// when the compiler can't prove equal sizes.
 #[inline]
 #[doc(hidden)]
-pub unsafe fn transmute<A, B>(a: A) -> B {
+pub const unsafe fn transmute<A, B>(a: A) -> B {
+    #[repr(C)]
+    union Union<A, B> {
+        a: ManuallyDrop<A>,
+        b: ManuallyDrop<B>,
+    }
+
     let a = ManuallyDrop::new(a);
-    ::core::ptr::read(&*a as *const A as *const B)
+    ManuallyDrop::into_inner(Union { a }.b)
 }
 
 #[cfg(test)]

--- a/tests/arr.rs
+++ b/tests/arr.rs
@@ -31,3 +31,9 @@ fn const_context() {
     const AR: generic_array::GenericArray<u8, typenum::U3> = arr![u8; 10, 20, 30];
     assert_eq!(format!("{:x}", AR), "0a141e");
 }
+
+#[test]
+fn repeat_expression() {
+    let ar = arr![u8; 0xc0; typenum::U4];
+    assert_eq!(format!("{:x}", ar), "c0c0c0c0");
+}

--- a/tests/arr.rs
+++ b/tests/arr.rs
@@ -25,3 +25,9 @@ fn with_trailing_comma() {
     let ar = arr![u8; 10, 20, 30, ];
     assert_eq!(format!("{:x}", ar), "0a141e");
 }
+
+#[test]
+fn const_context() {
+    const AR: generic_array::GenericArray<u8, typenum::U3> = arr![u8; 10, 20, 30];
+    assert_eq!(format!("{:x}", AR), "0a141e");
+}


### PR DESCRIPTION
Adds an analogue of the `[expr; LENGTH]` array initialiser to the `arr!`
macro, i.e. `arr![Type; expr; LENGTH]`.  Can be used in const contexts.

Note that this implementation builds upon #129, which should be
reviewed/merged before this.