### PR TITLE
Trait for default const values

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ more_lengths = []
 
 [dependencies]
 typenum = "1.12"
+const-default = { version = "1", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
 

--- a/src/impl_const_default.rs
+++ b/src/impl_const_default.rs
@@ -1,0 +1,27 @@
+//! Const default implementation
+
+use crate::{ArrayLength, GenericArray, GenericArrayImplEven, GenericArrayImplOdd};
+use const_default::ConstDefault;
+use core::marker::PhantomData;
+
+impl<T, U: ConstDefault> ConstDefault for GenericArrayImplEven<T, U> {
+    const DEFAULT: Self = Self {
+        parent1: U::DEFAULT,
+        parent2: U::DEFAULT,
+        _marker: PhantomData,
+    };
+}
+
+impl<T: ConstDefault, U: ConstDefault> ConstDefault for GenericArrayImplOdd<T, U> {
+    const DEFAULT: Self = Self {
+        parent1: U::DEFAULT,
+        parent2: U::DEFAULT,
+        data: T::DEFAULT,
+    };
+}
+
+impl<T, U: ArrayLength<T>> ConstDefault for GenericArray<T, U>
+where U::ArrayType: ConstDefault,
+{
+    const DEFAULT: Self = Self { data: ConstDefault::DEFAULT };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,9 @@
 #![deny(meta_variable_misuse)]
 #![no_std]
 
+#[cfg(feature = "const-default")]
+extern crate const_default;
+
 #[cfg(feature = "serde")]
 extern crate serde;
 
@@ -81,6 +84,9 @@ pub extern crate typenum;
 
 mod hex;
 mod impls;
+
+#[cfg(feature = "const-default")]
+mod impl_const_default;
 
 #[cfg(feature = "serde")]
 mod impl_serde;


### PR DESCRIPTION
Introduces a trait defining an associated constant of the `Self` type. An implementation is provided for `GenericArray`, providing means of constructing default `GenericArray`s in const context.

This plugs a gap that exists even if #130 is merged, as generic type parameters cannot currently be referenced in const context (e.g. if the repetition length provided to the `arr!` macro comes from a type parameter).