### PR TITLE
Docs: Make panicking behavior on from_slice more obvious

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -549,7 +549,9 @@ where
 
     /// Converts slice to a generic array reference with inferred length;
     ///
-    /// Length of the slice must be equal to the length of the array.
+    /// # Panics
+    ///
+    /// Panics if the slice is not equal to the length of the array.
     #[inline]
     pub fn from_slice(slice: &[T]) -> &GenericArray<T, N> {
         slice.into()
@@ -557,7 +559,9 @@ where
 
     /// Converts mutable slice to a mutable generic array reference
     ///
-    /// Length of the slice must be equal to the length of the array.
+    /// # Panics
+    ///
+    /// Panics if the slice is not equal to the length of the array.
     #[inline]
     pub fn from_mut_slice(slice: &mut [T]) -> &mut GenericArray<T, N> {
         slice.into()
@@ -567,7 +571,9 @@ where
 impl<'a, T, N: ArrayLength<T>> From<&'a [T]> for &'a GenericArray<T, N> {
     /// Converts slice to a generic array reference with inferred length;
     ///
-    /// Length of the slice must be equal to the length of the array.
+    /// # Panics
+    ///
+    /// Panics if the slice is not equal to the length of the array.
     #[inline]
     fn from(slice: &[T]) -> &GenericArray<T, N> {
         assert_eq!(slice.len(), N::USIZE);
@@ -579,7 +585,9 @@ impl<'a, T, N: ArrayLength<T>> From<&'a [T]> for &'a GenericArray<T, N> {
 impl<'a, T, N: ArrayLength<T>> From<&'a mut [T]> for &'a mut GenericArray<T, N> {
     /// Converts mutable slice to a mutable generic array reference
     ///
-    /// Length of the slice must be equal to the length of the array.
+    /// # Panics
+    ///
+    /// Panics if the slice is not equal to the length of the array.
     #[inline]
     fn from(slice: &mut [T]) -> &mut GenericArray<T, N> {
         assert_eq!(slice.len(), N::USIZE);
@@ -594,7 +602,9 @@ where
 {
     /// Construct a `GenericArray` from a slice by cloning its content
     ///
-    /// Length of the slice must be equal to the length of the array
+    /// # Panics
+    ///
+    /// Panics if the slice is not equal to the length of the array.
     #[inline]
     pub fn clone_from_slice(list: &[T]) -> GenericArray<T, N> {
         Self::from_exact_iter(list.iter().cloned())


### PR DESCRIPTION
This brings it in line with the format used in the Rust stdlib, e.g. [here](https://doc.rust-lang.org/std/string/struct.String.html#method.reserve).