### PR TITLE
Upgrade http links to https in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 
 license = "MIT"
 
-documentation = "http://fizyk20.github.io/generic-array/generic_array/"
+documentation = "https://fizyk20.github.io/generic-array/generic_array/"
 repository = "https://github.com/fizyk20/generic-array.git"
 
 keywords = ["generic", "array"]


### PR DESCRIPTION
This is an automatically-generated PR to update plain HTTP links in Cargo.toml

If there are any issues with this, you can reach out to @/Benjins on Github who is the original author of this automated PR

In file `Cargo.toml`:
 - `http://fizyk20.github.io/generic-array/generic_array/` was updated. The HTTPS version exists, but HTTP version does not redirect to it

