### PR TITLE
Faster hex encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,11 +32,23 @@ typenum = { version = "1.16", features = ["const-generics"] }
 const-default = { version = "1", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }
 zeroize = { version = "1", optional = true, default-features = false }
+faster-hex = { version = "0.8", optional = true, default-features = false }
 
 [dev-dependencies]
 # this can't yet be made optional, see https://github.com/rust-lang/cargo/issues/1596
 serde_json = "1.0"
 bincode = "1.0"
+criterion = { version = "0.5", features = ["html_reports"] }
+rand = "0.8"
+
+[[bench]]
+name = "hex"
+harness = false
+
+[profile.bench]
+opt-level = 3
+lto = 'fat'
+codegen-units = 1
 
 [package.metadata.docs.rs]
 # all but "internals", don't show those on docs.rs

--- a/benches/hex.rs
+++ b/benches/hex.rs
@@ -1,0 +1,46 @@
+use criterion::{
+    criterion_group, criterion_main, measurement::WallTime, BenchmarkGroup, Criterion,
+};
+use generic_array::{typenum::*, ArrayLength, GenericArray};
+use rand::RngCore;
+
+use std::{fmt::UpperHex, io::Write};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut hex = c.benchmark_group("hex");
+
+    let mut rng = rand::thread_rng();
+
+    macro_rules! all_hex_benches {
+        ($($len:ty,)*) => {
+            $(bench_hex::<$len>(&mut rng, &mut hex);)*
+        }
+    }
+
+    all_hex_benches!(
+        U1, U2, U4, U8, U12, U15, U16, U32, U64, U100, U128, U160, U255, U256, U500, U512, U900,
+        U1023, U1024, Sum<U1024, U1>, U2048, U4096, Prod<U1000, U5>, U10000,
+    );
+
+    hex.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);
+
+fn bench_hex<N: ArrayLength>(mut rng: impl RngCore, g: &mut BenchmarkGroup<'_, WallTime>)
+where
+    GenericArray<u8, N>: UpperHex,
+{
+    let mut fixture = Box::<GenericArray<u8, N>>::default();
+    rng.fill_bytes(fixture.as_mut_slice());
+
+    g.bench_function(format!("N{:08}", N::USIZE), |b| {
+        let mut out = Vec::with_capacity(N::USIZE * 2);
+
+        b.iter(|| {
+            _ = write!(out, "{:X}", &*fixture);
+            out.clear();
+        });
+    });
+}

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -18,12 +18,36 @@ use typenum::*;
 
 use crate::{ArrayLength, GenericArray};
 
-static LOWER_CHARS: [u8; 16] = *b"0123456789abcdef";
-static UPPER_CHARS: [u8; 16] = *b"0123456789ABCDEF";
+#[inline(always)]
+fn hex_encode_fallback<const UPPER: bool>(src: &[u8], dst: &mut [u8]) {
+    let alphabet = match UPPER {
+        true => b"0123456789ABCDEF",
+        false => b"0123456789abcdef",
+    };
 
-fn generic_hex<N: ArrayLength>(
+    dst.chunks_exact_mut(2).zip(src).for_each(|(s, c)| {
+        s[0] = alphabet[(c >> 4) as usize];
+        s[1] = alphabet[(c & 0xF) as usize];
+    });
+}
+
+#[cfg(feature = "faster-hex")]
+fn faster_hex_encode<const UPPER: bool>(src: &[u8], dst: &mut [u8]) {
+    debug_assert!(dst.len() >= (src.len() * 2));
+
+    #[cfg(miri)]
+    hex_encode_fallback::<UPPER>(src, dst);
+
+    // the `unwrap_unchecked` is to avoid the length checks
+    #[cfg(not(miri))]
+    match UPPER {
+        true => unsafe { faster_hex::hex_encode_upper(src, dst).unwrap_unchecked() },
+        false => unsafe { faster_hex::hex_encode(src, dst).unwrap_unchecked() },
+    };
+}
+
+fn generic_hex<N: ArrayLength, const UPPER: bool>(
     arr: &GenericArray<u8, N>,
-    alphabet: &[u8; 16], // use fixed-length array to avoid slice index checks
     f: &mut fmt::Formatter<'_>,
 ) -> fmt::Result
 where
@@ -36,32 +60,50 @@ where
         _ => max_digits,
     };
 
-    let max_hex = (max_digits >> 1) + (max_digits & 1);
+    // ceil(max_digits / 2)
+    let max_bytes = (max_digits >> 1) + (max_digits & 1);
+
+    let input = {
+        // LLVM can't seem to automatically prove this
+        if max_bytes > N::USIZE {
+            unsafe { core::hint::unreachable_unchecked() };
+        }
+
+        &arr[..max_bytes]
+    };
 
     if N::USIZE <= 1024 {
-        // For small arrays use a stack allocated
-        // buffer of 2x number of bytes
-        let mut res = GenericArray::<u8, Sum<N, N>>::default();
+        // For small arrays use a stack allocated buffer of 2x number of bytes
+        let mut buf = GenericArray::<u8, Sum<N, N>>::default();
 
-        arr.iter().take(max_hex).enumerate().for_each(|(i, c)| {
-            res[i * 2] = alphabet[(c >> 4) as usize];
-            res[i * 2 + 1] = alphabet[(c & 0xF) as usize];
-        });
+        if N::USIZE < 16 {
+            // for the smallest inputs, don't bother limiting to max_bytes,
+            // just process the entire array. When "faster-hex" is enabled,
+            // this avoids its logic that winds up going to the fallback anyway
+            hex_encode_fallback::<UPPER>(arr, &mut buf);
+        } else if cfg!(not(feature = "faster-hex")) {
+            hex_encode_fallback::<UPPER>(input, &mut buf);
+        } else {
+            #[cfg(feature = "faster-hex")]
+            faster_hex_encode::<UPPER>(input, &mut buf);
+        }
 
-        f.write_str(unsafe { str::from_utf8_unchecked(&res[..max_digits]) })?;
+        f.write_str(unsafe { str::from_utf8_unchecked(buf.get_unchecked(..max_digits)) })?;
     } else {
         // For large array use chunks of up to 1024 bytes (2048 hex chars)
         let mut buf = [0u8; 2048];
         let mut digits_left = max_digits;
 
-        for chunk in arr[..max_hex].chunks(1024) {
-            chunk.iter().enumerate().for_each(|(i, c)| {
-                buf[i * 2] = alphabet[(c >> 4) as usize];
-                buf[i * 2 + 1] = alphabet[(c & 0xF) as usize];
-            });
+        for chunk in input.chunks(1024) {
+            #[cfg(feature = "faster-hex")]
+            faster_hex_encode::<UPPER>(chunk, &mut buf);
+
+            #[cfg(not(feature = "faster-hex"))]
+            hex_encode_fallback::<UPPER>(chunk, buf);
 
             let n = min(chunk.len() * 2, digits_left);
-            f.write_str(unsafe { str::from_utf8_unchecked(&buf[..n]) })?;
+            // SAFETY: n will always be within bounds due to the above min
+            f.write_str(unsafe { str::from_utf8_unchecked(buf.get_unchecked(..n)) })?;
             digits_left -= n;
         }
     }
@@ -73,8 +115,9 @@ where
     N: Add<N>,
     Sum<N, N>: ArrayLength,
 {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        generic_hex(self, &LOWER_CHARS, f)
+        generic_hex::<_, false>(self, f)
     }
 }
 
@@ -83,7 +126,8 @@ where
     N: Add<N>,
     Sum<N, N>: ArrayLength,
 {
+    #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        generic_hex(self, &UPPER_CHARS, f)
+        generic_hex::<_, true>(self, f)
     }
 }

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -99,7 +99,7 @@ where
             faster_hex_encode::<UPPER>(chunk, &mut buf);
 
             #[cfg(not(feature = "faster-hex"))]
-            hex_encode_fallback::<UPPER>(chunk, buf);
+            hex_encode_fallback::<UPPER>(chunk, &mut buf);
 
             let n = min(chunk.len() * 2, digits_left);
             // SAFETY: n will always be within bounds due to the above min


### PR DESCRIPTION
Optimizes the standard encoding, plus adds support for using the `faster-hex` crate for SIMD-accelerated encoding.

<details>
<summary>Expand for benchmarks table</summary>

| N | Before |  After | Change |
|---:|---|---|:---:|
| 1 | 16.220 ns | 16.010 ns | -1.30% |
| 2 | 17.035 ns | 16.019 ns | -5.96% |
| 4 | 17.765 ns | 17.000 ns | -4.31% |
| 8 | 18.798 ns | 18.640 ns | -0.84% |
| 12 | 21.002 ns | 20.106 ns | -4.27% |
| 15 | 22.648 ns | 21.692 ns | -4.22% |
| 16 | 22.495 ns | 15.583 ns | -30.73% |
| 32 | 32.556 ns | 16.930 ns | -48.00% |
| 64 | 50.232 ns | 19.022 ns | -62.13% |
| 100 | 70.175 ns | 23.459 ns | -66.57% |
| 128 | 87.228 ns | 20.423 ns | -76.59% |
| 160 | 105.057 ns | 22.228 ns | -78.84% |
| 255 | 156.836 ns | 34.361 ns | -78.09% |
| 256 | 182.728 ns | 25.557 ns | -86.01% |
| 500 | 293.572 ns | 41.154 ns | -85.98% |
| 512 | 352.274 ns | 38.409 ns | -89.10% |
| 900 | 610.794 ns | 63.040 ns | -89.68% |
| 1023 | 585.836 ns | 74.845 ns | -87.22% |
| 1024 | 586.594 ns | 65.048 ns | -88.91% |
| 1025 | 505.389 ns | 72.909 ns | -85.57% |
| 2048 | 975.273 ns | 110.846 ns | -88.63% |
| 4096 | 1945.770 ns | 201.676 ns | -89.64% |
| 5000 | 2343.561 ns | 250.155 ns | -89.33% |
| 10000 | 4698.586 ns | 509.036 ns | -89.17% |

</details>

It's worth noting at least 10-16ns of those benchmarks seems to be spent on non-encoding things. In fact it was made worse when I upgraded to Rust 1.72.0 today, but only in terms of that base offset.

I'm not super happy about the `unsafe` usage here, but when mixing the fmt precision in like that LLVM has a harder time reasoning with it. 