### PR TITLE
add GenericArray::remove, remove_unchecked

### DIFF
--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -473,3 +473,55 @@ fn test_chunks_fail() {
     assert!(chunks.is_empty());
     assert!(rem.is_empty());
 }
+
+#[test]
+fn test_remove_various_sizes() {
+    let a = arr![1u8, 2, 3, 4];
+    assert_eq!((arr![2, 3, 4], 1), a.remove(0));
+    assert_eq!((arr![1, 3, 4], 2), a.remove(1));
+    assert_eq!((arr![1, 2, 4], 3), a.remove(2));
+    assert_eq!((arr![1, 2, 3], 4), a.remove(3));
+    let a = arr![1u16, 2, 3, 4];
+    assert_eq!((arr![2, 3, 4], 1), a.remove(0));
+    assert_eq!((arr![1, 3, 4], 2), a.remove(1));
+    assert_eq!((arr![1, 2, 4], 3), a.remove(2));
+    assert_eq!((arr![1, 2, 3], 4), a.remove(3));
+    let a = arr![1u32, 2, 3, 4];
+    assert_eq!((arr![2, 3, 4], 1), a.remove(0));
+    assert_eq!((arr![1, 3, 4], 2), a.remove(1));
+    assert_eq!((arr![1, 2, 4], 3), a.remove(2));
+    assert_eq!((arr![1, 2, 3], 4), a.remove(3));
+    let a = arr![1u64, 2, 3, 4];
+    assert_eq!((arr![2, 3, 4], 1), a.remove(0));
+    assert_eq!((arr![1, 3, 4], 2), a.remove(1));
+    assert_eq!((arr![1, 2, 4], 3), a.remove(2));
+    assert_eq!((arr![1, 2, 3], 4), a.remove(3));
+    let a = arr![1u128, 2, 3, 4];
+    assert_eq!((arr![2, 3, 4], 1), a.remove(0));
+    assert_eq!((arr![1, 3, 4], 2), a.remove(1));
+    assert_eq!((arr![1, 2, 4], 3), a.remove(2));
+    assert_eq!((arr![1, 2, 3], 4), a.remove(3));
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn test_remove_drop_type() {
+    use alloc::vec;
+    let a = arr![vec![1], vec![2], vec![3, 4]];
+    assert_eq!((arr![vec![2], vec![3, 4]], vec![1]), a.clone().remove(0));
+    assert_eq!((arr![vec![1], vec![3, 4]], vec![2]), a.clone().remove(1));
+    assert_eq!((arr![vec![1], vec![2]], vec![3, 4]), a.remove(2));
+}
+
+#[test]
+fn test_remove_length_one() {
+    let a = arr![1];
+    assert_eq!((arr![], 1), a.remove(0));
+}
+
+#[test]
+fn test_remove_zst() {
+    let a = arr![(), ()];
+    assert_eq!((arr![()], ()), a.remove(0));
+    assert_eq!((arr![], ()), a.remove(0).0.remove(0));
+}


### PR DESCRIPTION
Add new methods for removing an element from an arbitrary index. I'm surprised this wasn't already implemented, so maybe I missed it.

Here's what the assembly looks like for `GenericArray::<u8,4>.remove_unchecked`

Ignoring the removed element:
```asm
	sub rsp, 40
	mov r8, rdx

	mov dword ptr [rsp + 36], ecx

	lea rcx, [rsp + rdx]

	add rcx, 36

	add rdx, rsp

	add rdx, 37

	xor r8, 3

	call memmove

	mov eax, dword ptr [rsp + 36]

	add rsp, 40
	ret
```

Ignoring the remaining array:
```asm
	push rax

	mov dword ptr [rsp + 4], ecx

	movzx eax, byte ptr [rsp + rdx + 4]

	pop rcx

	ret
```

Using both the remaining array and element:
```asm
	push rsi
	sub rsp, 48
	mov r8, rdx

	mov dword ptr [rsp + 44], ecx

	lea rcx, [rsp + rdx]

	add rcx, 44

	add rdx, rsp

	add rdx, 45

	movzx esi, byte ptr [rsp + r8 + 44]

	xor r8, 3

	call memmove

	shl esi, 24
	mov eax, 16777215
	and eax, dword ptr [rsp + 44]
	or eax, esi

	add rsp, 48
	pop rsi
	ret
```