### PR TITLE
fix docs: subset?

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ pub use self::iter::GenericArrayIter;
 
 /// Trait used to define the number of elements in a [`GenericArray`].
 ///
-/// `ArrayLength` is a superset of [`typenum::Unsigned`].
+/// `ArrayLength` is a subset of [`typenum::Unsigned`].
 ///
 /// Consider `N: ArrayLength` to be equivalent to `const N: usize`
 ///


### PR DESCRIPTION
all `ArrayLength`s are `Unsigned`