### PR TITLE
chore: fix cargo clippy warning

### DIFF
--- a/src/arr.rs
+++ b/src/arr.rs
@@ -19,7 +19,7 @@
 /// # NOTES AND LIMITATIONS
 /// * As of `generic-array 1.0`, [`From`]/[`from_array`](crate::GenericArray::from_array) can be used directly for a wide range of regular arrays.
 /// * The `[T; N: ArrayLength]` and `[T; usize]` explicit forms are limited to `Copy` values. Use
-///     [`GenericArray::generate(|| value.clone())`](crate::GenericSequence::generate) for non-`Copy` items.
+///   [`GenericArray::generate(|| value.clone())`](crate::GenericSequence::generate) for non-`Copy` items.
 /// * The `[T; usize]` explicit and `[0, 1, 2, 3]` implicit forms are limited to lengths supported by [`Const<U>`](typenum::Const)
 #[macro_export]
 macro_rules! arr {


### PR DESCRIPTION
Running cargo clippy reports the following error.

```shell
warning: doc list item overindented
  --> src/arr.rs:22:5
   |
22 | ///     [`GenericArray::generate(|| value.clone())`](crate::GenericSequence::generate) for n...
   |     ^^^^ help: try using `  ` (2 spaces)
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#doc_overindented_list_items
   = note: `#[warn(clippy::doc_overindented_list_items)]` on by default

```

This commit resolves the issue.

