### PR TITLE
Remove doc_auto_cfg

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@
 #![deny(missing_docs)]
 #![deny(meta_variable_misuse)]
 #![no_std]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub extern crate typenum;
 


### PR DESCRIPTION
doc_auto_cfg was merged into doc_cfg in rust-lang/rust#138907

Would be nice to put a release out containing this fix as nightly docs of any crate that indirectly depends on generic-array fails. 